### PR TITLE
refactor(phase-2): introduce Logger, retire AtomicBool suppress and Option<&mut File>

### DIFF
--- a/crates/pid-ctl/src/app/logger.rs
+++ b/crates/pid-ctl/src/app/logger.rs
@@ -1,0 +1,93 @@
+//! Owned log sink: writes structured NDJSON to `--log` file and/or stderr.
+//!
+//! Replaces the `Option<&mut std::fs::File>` that was previously threaded through every
+//! emit site.  When `suppress_stderr` is set, events go to `--log` only — used by
+//! `loop --tune` so JSON lines do not interleave with the ratatui TUI.
+
+use serde::Serialize;
+use std::io::{self, Write};
+use std::path::Path;
+
+pub struct Logger {
+    file: Option<std::fs::File>,
+    suppress_stderr: bool,
+}
+
+impl Logger {
+    /// Opens (or creates, append-mode) a log file at `path`, or returns a no-op
+    /// logger when `path` is `None`.
+    ///
+    /// # Errors
+    /// Returns `io::Error` when the file cannot be opened or created.
+    pub fn open(path: Option<&Path>) -> io::Result<Self> {
+        match path {
+            Some(p) => {
+                let file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(p)?;
+                Ok(Self {
+                    file: Some(file),
+                    suppress_stderr: false,
+                })
+            }
+            None => Ok(Self::none()),
+        }
+    }
+
+    /// No-op logger: no file, no stderr output.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            file: None,
+            suppress_stderr: false,
+        }
+    }
+
+    /// Suppresses stderr; events are written to `--log` only.
+    #[must_use]
+    pub fn suppressed(self) -> Self {
+        Self {
+            suppress_stderr: true,
+            ..self
+        }
+    }
+
+    /// Writes a structured JSON event to stderr (unless suppressed) and to `--log` if set.
+    pub fn write_event<T: Serialize>(&mut self, record: &T) {
+        let Ok(json) = serde_json::to_string(record) else {
+            return;
+        };
+        if !self.suppress_stderr {
+            eprintln!("{json}");
+        }
+        if let Some(f) = &mut self.file {
+            let _ = writeln!(f, "{json}");
+        }
+    }
+
+    /// Writes an iteration record to `--log` only (never to stderr).
+    pub fn write_iteration_line<T: Serialize>(&mut self, record: &T) {
+        if let Some(f) = &mut self.file
+            && let Ok(json) = serde_json::to_string(record)
+        {
+            let _ = writeln!(f, "{json}");
+        }
+    }
+}
+
+#[cfg(test)]
+impl Logger {
+    #[must_use]
+    pub fn from_file(file: std::fs::File) -> Self {
+        Self {
+            file: Some(file),
+            suppress_stderr: false,
+        }
+    }
+
+    #[must_use]
+    pub fn into_file(self) -> Option<std::fs::File> {
+        self.file
+    }
+}

--- a/crates/pid-ctl/src/app/loop_runtime.rs
+++ b/crates/pid-ctl/src/app/loop_runtime.rs
@@ -2,10 +2,10 @@
 //! reporting, and the [`LoopControls`] abstraction used by both the main loop and socket dispatch.
 
 use crate::adapters::CvSink;
+use crate::app::logger::Logger;
 use crate::app::{ControllerSession, StateStoreError};
 use crate::json_events;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 pub enum MeasuredDt {
@@ -59,21 +59,6 @@ pub fn millis_round_u64(ms: f64) -> u64 {
     v as u64
 }
 
-/// # Errors
-/// Returns an `io::Error` if the file cannot be opened or created.
-pub fn open_log_optional(path: Option<&Path>) -> io::Result<Option<std::fs::File>> {
-    match path {
-        Some(p) => {
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(p)?;
-            Ok(Some(file))
-        }
-        None => Ok(None),
-    }
-}
-
 /// Applies `--min-dt` / `--max-dt` for measured `dt` in `loop`: skip (default) or clamp (`--dt-clamp`).
 pub fn apply_measured_dt(
     raw_dt: f64,
@@ -81,7 +66,7 @@ pub fn apply_measured_dt(
     max_dt: f64,
     dt_clamp: bool,
     quiet: bool,
-    log: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> MeasuredDt {
     if raw_dt >= min_dt && raw_dt <= max_dt {
         return MeasuredDt::Use(raw_dt);
@@ -96,7 +81,7 @@ pub fn apply_measured_dt(
                 eprintln!("dt {raw_dt:.6}s exceeds max_dt {max_dt:.6}s — clamping to max_dt");
             }
         }
-        json_events::emit_dt_clamped(log, raw_dt, clamped);
+        json_events::emit_dt_clamped(logger, raw_dt, clamped);
         MeasuredDt::Use(clamped)
     } else {
         if !quiet {
@@ -106,7 +91,7 @@ pub fn apply_measured_dt(
                 eprintln!("dt {raw_dt:.6}s exceeds max_dt {max_dt:.6}s — skipping tick");
             }
         }
-        json_events::emit_dt_skipped(log, raw_dt, min_dt, max_dt);
+        json_events::emit_dt_skipped(logger, raw_dt, min_dt, max_dt);
         MeasuredDt::Skip
     }
 }
@@ -130,20 +115,20 @@ pub fn handle_dt_skip_state_write(
     err: Option<StateStoreError>,
     session: &ControllerSession,
     state_path: Option<&PathBuf>,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     quiet: bool,
 ) {
     let Some(err) = err else {
         return;
     };
-    emit_state_write_failure(session, state_path, log_file, &err, quiet);
+    emit_state_write_failure(session, state_path, logger, &err, quiet);
 }
 
 /// Emits a state write failure — escalated warning if threshold reached, plain log otherwise.
 pub fn emit_state_write_failure(
     session: &ControllerSession,
     state_path: Option<&PathBuf>,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     err: &StateStoreError,
     quiet: bool,
 ) {
@@ -153,12 +138,12 @@ pub fn emit_state_write_failure(
             if !quiet {
                 eprintln!("WARNING: state write failing persistently ({count} consecutive): {err}");
             }
-            json_events::emit_state_write_escalated(log_file, path.clone(), err.to_string(), count);
+            json_events::emit_state_write_escalated(logger, path.clone(), err.to_string(), count);
         } else {
             if !quiet {
                 eprintln!("state write failed: {err}");
             }
-            json_events::emit_state_write_failed(log_file, path.clone(), err.to_string());
+            json_events::emit_state_write_failed(logger, path.clone(), err.to_string());
         }
     } else if !quiet {
         eprintln!("state write failed: {err}");
@@ -169,12 +154,12 @@ pub fn emit_state_write_failure(
 pub fn flush_state_at_shutdown(
     session: &mut ControllerSession,
     state_path: Option<&PathBuf>,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) {
     if let Some(err) = session.force_flush() {
         eprintln!("state write failed at shutdown: {err}");
         if let Some(path) = state_path {
-            json_events::emit_state_write_failed(log_file, path.clone(), err.to_string());
+            json_events::emit_state_write_failed(logger, path.clone(), err.to_string());
         }
     }
 }

--- a/crates/pid-ctl/src/app/mod.rs
+++ b/crates/pid-ctl/src/app/mod.rs
@@ -1,6 +1,7 @@
 //! Controller session scaffolding and persistence primitives for the application layer.
 
 pub mod adapters_build;
+pub mod logger;
 pub mod loop_runtime;
 #[cfg(unix)]
 pub mod socket_dispatch;

--- a/crates/pid-ctl/src/app/socket_dispatch.rs
+++ b/crates/pid-ctl/src/app/socket_dispatch.rs
@@ -5,6 +5,7 @@
 //! Side effects (hold, resume, interval change) are signalled via [`SocketSideEffect`].
 
 use crate::app::ControllerSession;
+use crate::app::logger::Logger;
 use crate::app::loop_runtime::LoopControls;
 use crate::json_events;
 use crate::socket::{Request, Response};
@@ -24,7 +25,7 @@ pub fn handle_socket_request(
     req: &Request,
     session: &mut ControllerSession,
     controls: &mut dyn LoopControls,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> (Response, SocketSideEffect) {
     match req {
         Request::Status => {
@@ -46,12 +47,12 @@ pub fn handle_socket_request(
             )
         }
         Request::Set { param, value } => {
-            handle_socket_set(param, *value, session, controls, log_file)
+            handle_socket_set(param, *value, session, controls, logger)
         }
         Request::Reset => {
             let i_acc_before = session.i_acc();
             session.reset_integral();
-            json_events::emit_integral_reset(log_file, i_acc_before, session.iter(), "socket");
+            json_events::emit_integral_reset(logger, i_acc_before, session.iter(), "socket");
             (
                 Response::Reset {
                     ok: true,
@@ -113,7 +114,7 @@ fn apply_gain_param(
     param: &str,
     value: f64,
     session: &mut ControllerSession,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> f64 {
     let idx = match param {
         "kp" => 0usize,
@@ -127,7 +128,7 @@ fn apply_gain_param(
     gains[idx] = value;
     session.set_gains(gains[0], gains[1], gains[2]);
     json_events::emit_gains_changed(
-        log_file,
+        logger,
         session.config().kp,
         session.config().ki,
         session.config().kd,
@@ -143,7 +144,7 @@ fn handle_socket_set(
     value: f64,
     session: &mut ControllerSession,
     controls: &mut dyn LoopControls,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> (Response, SocketSideEffect) {
     use crate::app::loop_runtime::apply_runtime_interval;
     use std::time::Duration;
@@ -160,7 +161,7 @@ fn handle_socket_set(
 
     match param {
         "kp" | "ki" | "kd" => {
-            let old = apply_gain_param(param, value, session, log_file);
+            let old = apply_gain_param(param, value, session, logger);
             (
                 Response::Set {
                     ok: true,
@@ -175,7 +176,7 @@ fn handle_socket_set(
             let old = session.config().setpoint;
             session.set_setpoint(value);
             json_events::emit_gains_changed(
-                log_file,
+                logger,
                 session.config().kp,
                 session.config().ki,
                 session.config().kd,

--- a/crates/pid-ctl/src/json_events.rs
+++ b/crates/pid-ctl/src/json_events.rs
@@ -1,45 +1,15 @@
 //! Structured NDJSON event lines (stderr + optional `--log` file).
 //!
-//! [`suppress_structured_json_stderr`] disables stderr for `emit_*` only (not other `eprintln!`),
-//! so `loop --tune` can use an alternate-screen TUI on stdout without JSON lines corrupting the
-//! display — events still append to `--log` when set.
+//! All `emit_*` functions take `&mut Logger`; stderr suppression is controlled
+//! by [`Logger::suppressed`] rather than a process-global flag.
 
+use crate::app::logger::Logger;
 use crate::app::{STATE_SCHEMA_VERSION, now_iso8601};
 use serde::Serialize;
-use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 
-static SUPPRESS_STRUCTURED_JSON_STDERR: AtomicBool = AtomicBool::new(false);
-
-fn emit_line(log: &mut Option<std::fs::File>, record: &impl Serialize) {
-    let Ok(json) = serde_json::to_string(record) else {
-        return;
-    };
-    if !SUPPRESS_STRUCTURED_JSON_STDERR.load(Ordering::Relaxed) {
-        eprintln!("{json}");
-    }
-    if let Some(f) = log {
-        let _ = writeln!(f, "{json}");
-    }
-}
-
-/// While held, structured NDJSON events are written to `--log` only, not stderr.
-///
-/// Used by `loop --tune` so `emit_*` lines do not interleave with the ratatui display (stderr is not
-/// in the alternate screen buffer).
-#[must_use]
-pub fn suppress_structured_json_stderr() -> StructuredJsonStderrGuard {
-    SUPPRESS_STRUCTURED_JSON_STDERR.store(true, Ordering::Relaxed);
-    StructuredJsonStderrGuard
-}
-
-pub struct StructuredJsonStderrGuard;
-
-impl Drop for StructuredJsonStderrGuard {
-    fn drop(&mut self) {
-        SUPPRESS_STRUCTURED_JSON_STDERR.store(false, Ordering::Relaxed);
-    }
+fn emit_line(logger: &mut Logger, record: &impl Serialize) {
+    logger.write_event(record);
 }
 
 /// Generates a serialisable event struct with the common envelope fields
@@ -77,8 +47,8 @@ macro_rules! event_struct {
             }
         }
 
-        pub fn $emit(log: &mut Option<std::fs::File>) {
-            emit_line(log, &$name::new());
+        pub fn $emit(logger: &mut Logger) {
+            emit_line(logger, &$name::new());
         }
     };
 
@@ -106,8 +76,8 @@ macro_rules! event_struct {
             }
         }
 
-        pub fn $emit(log: &mut Option<std::fs::File>, $( $field: $ty ),+) {
-            emit_line(log, &$name::new($( $field ),+));
+        pub fn $emit(logger: &mut Logger, $( $field: $ty ),+) {
+            emit_line(logger, &$name::new($( $field ),+));
         }
     };
 }
@@ -205,11 +175,11 @@ impl PvReadFailureEvent {
 }
 
 pub fn emit_pv_read_failure(
-    log: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     error: impl Into<String>,
     safe_cv: Option<f64>,
 ) {
-    emit_line(log, &PvReadFailureEvent::new(error, safe_cv));
+    emit_line(logger, &PvReadFailureEvent::new(error, safe_cv));
 }
 
 /// D-term skipped event — payload uses `&'static str` reason derived from enum variant.
@@ -246,11 +216,11 @@ pub const fn reason_str(reason: pid_ctl_core::DTermSkipReason) -> &'static str {
 }
 
 pub fn emit_d_term_skipped(
-    log: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     reason: pid_ctl_core::DTermSkipReason,
     iter: u64,
 ) {
-    emit_line(log, &DTermSkippedEvent::new(reason_str(reason), iter));
+    emit_line(logger, &DTermSkippedEvent::new(reason_str(reason), iter));
 }
 
 #[cfg(test)]
@@ -259,11 +229,10 @@ mod tests {
     use std::io::{Read, Seek, SeekFrom};
 
     #[test]
-    fn suppress_guard_still_appends_to_log() {
-        let mut log = Some(tempfile::tempfile().unwrap());
-        let _guard = suppress_structured_json_stderr();
-        emit_gains_changed(&mut log, 1.0, 0.0, 0.0, 1.0, 1, "tui");
-        let mut f = log.unwrap();
+    fn suppressed_logger_still_appends_to_log() {
+        let mut logger = Logger::from_file(tempfile::tempfile().unwrap()).suppressed();
+        emit_gains_changed(&mut logger, 1.0, 0.0, 0.0, 1.0, 1, "tui");
+        let mut f = logger.into_file().unwrap();
         let mut s = String::new();
         f.seek(SeekFrom::Start(0)).unwrap();
         f.read_to_string(&mut s).unwrap();
@@ -272,9 +241,9 @@ mod tests {
 
     #[test]
     fn socket_ready_event_fields() {
-        let mut log = Some(tempfile::tempfile().unwrap());
-        emit_socket_ready(&mut log, std::path::PathBuf::from("/tmp/ctl.sock"));
-        let mut f = log.unwrap();
+        let mut logger = Logger::from_file(tempfile::tempfile().unwrap());
+        emit_socket_ready(&mut logger, std::path::PathBuf::from("/tmp/ctl.sock"));
+        let mut f = logger.into_file().unwrap();
         let mut s = String::new();
         f.seek(SeekFrom::Start(0)).unwrap();
         f.read_to_string(&mut s).unwrap();
@@ -285,9 +254,9 @@ mod tests {
 
     #[test]
     fn integral_reset_event_fields() {
-        let mut log = Some(tempfile::tempfile().unwrap());
-        emit_integral_reset(&mut log, 42.5, 7, "socket");
-        let mut f = log.unwrap();
+        let mut logger = Logger::from_file(tempfile::tempfile().unwrap());
+        emit_integral_reset(&mut logger, 42.5, 7, "socket");
+        let mut f = logger.into_file().unwrap();
         let mut s = String::new();
         f.seek(SeekFrom::Start(0)).unwrap();
         f.read_to_string(&mut s).unwrap();
@@ -305,9 +274,9 @@ mod tests {
 
     #[test]
     fn macro_generated_events_have_correct_envelope() {
-        let mut log = Some(tempfile::tempfile().unwrap());
-        emit_dt_skipped(&mut log, 0.6, 0.1, 0.5);
-        let mut f = log.unwrap();
+        let mut logger = Logger::from_file(tempfile::tempfile().unwrap());
+        emit_dt_skipped(&mut logger, 0.6, 0.1, 0.5);
+        let mut f = logger.into_file().unwrap();
         let mut s = String::new();
         f.seek(SeekFrom::Start(0)).unwrap();
         f.read_to_string(&mut s).unwrap();
@@ -322,9 +291,9 @@ mod tests {
 
     #[test]
     fn pv_read_failure_safe_cv_skipped_when_none() {
-        let mut log = Some(tempfile::tempfile().unwrap());
-        emit_pv_read_failure(&mut log, "timeout", None);
-        let mut f = log.unwrap();
+        let mut logger = Logger::from_file(tempfile::tempfile().unwrap());
+        emit_pv_read_failure(&mut logger, "timeout", None);
+        let mut f = logger.into_file().unwrap();
         let mut s = String::new();
         f.seek(SeekFrom::Start(0)).unwrap();
         f.read_to_string(&mut s).unwrap();

--- a/crates/pid-ctl/src/json_events.rs
+++ b/crates/pid-ctl/src/json_events.rs
@@ -174,11 +174,7 @@ impl PvReadFailureEvent {
     }
 }
 
-pub fn emit_pv_read_failure(
-    logger: &mut Logger,
-    error: impl Into<String>,
-    safe_cv: Option<f64>,
-) {
+pub fn emit_pv_read_failure(logger: &mut Logger, error: impl Into<String>, safe_cv: Option<f64>) {
     emit_line(logger, &PvReadFailureEvent::new(error, safe_cv));
 }
 
@@ -215,11 +211,7 @@ pub const fn reason_str(reason: pid_ctl_core::DTermSkipReason) -> &'static str {
     }
 }
 
-pub fn emit_d_term_skipped(
-    logger: &mut Logger,
-    reason: pid_ctl_core::DTermSkipReason,
-    iter: u64,
-) {
+pub fn emit_d_term_skipped(logger: &mut Logger, reason: pid_ctl_core::DTermSkipReason, iter: u64) {
     emit_line(logger, &DTermSkippedEvent::new(reason_str(reason), iter));
 }
 

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -7,9 +7,10 @@ pub(crate) use cli::*;
 use clap::Parser;
 use pid_ctl::adapters::{CvSink, DryRunCvSink, StdoutCvSink};
 use pid_ctl::app::adapters_build::{build_cv_sink, build_pv_source};
+use pid_ctl::app::logger::Logger;
 use pid_ctl::app::loop_runtime::{
     MeasuredDt, apply_measured_dt, emit_state_write_failure, flush_state_at_shutdown,
-    handle_dt_skip_state_write, millis_round_u64, open_log_optional, write_safe_cv,
+    handle_dt_skip_state_write, millis_round_u64, write_safe_cv,
 };
 use pid_ctl::app::{self, ControllerSession, StateSnapshot, StateStore};
 use pid_ctl::json_events;
@@ -109,8 +110,8 @@ fn run(
     }
 }
 
-fn open_log(path: Option<&Path>) -> Result<Option<std::fs::File>, CliError> {
-    open_log_optional(path).map_err(|e| {
+fn open_log(path: Option<&Path>) -> Result<Logger, CliError> {
+    Logger::open(path).map_err(|e| {
         CliError::new(
             1,
             format!("failed to open log file {}: {e}", path.unwrap().display()),
@@ -132,9 +133,9 @@ fn run_once(args: &OnceArgs) -> Result<(), CliError> {
             args.cmd_timeout,
         )
     };
-    let mut log_file = open_log(args.log_path.as_deref())?;
+    let mut logger = open_log(args.log_path.as_deref())?;
 
-    let dt = resolve_once_dt(&session, args, &mut log_file);
+    let dt = resolve_once_dt(&session, args, &mut logger);
 
     let raw_pv = resolve_pv(&args.pv_source, args.pv_cmd_timeout)
         .map_err(|error| CliError::new(1, format!("failed to read PV: {error}")))?;
@@ -142,23 +143,19 @@ fn run_once(args: &OnceArgs) -> Result<(), CliError> {
     match session.process_pv(scaled_pv, dt, sink.as_mut()) {
         Ok(outcome) => {
             if let Some(reason) = outcome.d_term_skipped {
-                json_events::emit_d_term_skipped(&mut log_file, reason, outcome.record.iter);
+                json_events::emit_d_term_skipped(&mut logger, reason, outcome.record.iter);
             }
 
             if matches!(args.output_format, OutputFormat::Json) {
                 print_iteration_json(&outcome.record)?;
             }
 
-            if let Some(file) = log_file.as_mut()
-                && let Ok(json) = serde_json::to_string(&outcome.record)
-            {
-                let _ = writeln!(file, "{json}");
-            }
+            logger.write_iteration_line(&outcome.record);
 
             if let Some(error) = outcome.state_write_failed {
                 if let Some(path) = &args.state_path {
                     json_events::emit_state_write_failed(
-                        &mut log_file,
+                        &mut logger,
                         path.clone(),
                         error.to_string(),
                     );
@@ -172,7 +169,7 @@ fn run_once(args: &OnceArgs) -> Result<(), CliError> {
             Ok(())
         }
         Err(error) => {
-            json_events::emit_cv_write_failed(&mut log_file, error.to_string(), 1);
+            json_events::emit_cv_write_failed(&mut logger, error.to_string(), 1);
             Err(CliError::new(5, error.to_string()))
         }
     }
@@ -184,7 +181,7 @@ fn run_pipe(args: &PipeArgs) -> Result<(), CliError> {
     let mut sink = StdoutCvSink {
         precision: args.cv_precision,
     };
-    let mut log_file = open_log(args.log_path.as_deref())?;
+    let mut logger = open_log(args.log_path.as_deref())?;
 
     // Monotonic clock for dt: use elapsed time between lines (plan §dt handling).
     // First line uses args.dt (no prior tick to measure from).
@@ -208,20 +205,16 @@ fn run_pipe(args: &PipeArgs) -> Result<(), CliError> {
             .map_err(|error| CliError::new(1, error.to_string()))?;
 
         if let Some(reason) = outcome.d_term_skipped {
-            json_events::emit_d_term_skipped(&mut log_file, reason, outcome.record.iter);
+            json_events::emit_d_term_skipped(&mut logger, reason, outcome.record.iter);
         }
 
-        if let Some(file) = log_file.as_mut()
-            && let Ok(json) = serde_json::to_string(&outcome.record)
-        {
-            let _ = writeln!(file, "{json}");
-        }
+        logger.write_iteration_line(&outcome.record);
 
         if let Some(error) = outcome.state_write_failed {
             emit_state_write_failure(
                 &session,
                 args.state_path.as_ref(),
-                &mut log_file,
+                &mut logger,
                 &error,
                 false,
             );
@@ -249,7 +242,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         )
     };
 
-    let mut log_file = open_log(args.log_path.as_deref())?;
+    let mut logger = open_log(args.log_path.as_deref())?;
 
     // Bind socket listener when --socket is set.
     #[cfg(unix)]
@@ -262,7 +255,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
                 ),
                 other => CliError::new(1, format!("socket: {other}")),
             })?;
-        json_events::emit_socket_ready(&mut log_file, path.clone());
+        json_events::emit_socket_ready(&mut logger, path.clone());
         Some(listener)
     } else {
         None
@@ -286,7 +279,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         // Check shutdown flag at top of each iteration.
         if shutdown.load(Ordering::Relaxed) {
             write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-            flush_state_at_shutdown(&mut session, args.state_path.as_ref(), &mut log_file);
+            flush_state_at_shutdown(&mut session, args.state_path.as_ref(), &mut logger);
             break;
         }
 
@@ -302,7 +295,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
                     args,
                     &mut hold,
                     &shutdown,
-                    &mut log_file,
+                    &mut logger,
                 );
             } else {
                 std::thread::sleep(next_deadline - now);
@@ -314,7 +307,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         // Check shutdown again after sleeping (signal may have arrived during sleep).
         if shutdown.load(Ordering::Relaxed) {
             write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-            flush_state_at_shutdown(&mut session, args.state_path.as_ref(), &mut log_file);
+            flush_state_at_shutdown(&mut session, args.state_path.as_ref(), &mut logger);
             break;
         }
 
@@ -343,7 +336,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
             }
             let interval_ms = millis_round_u64(interval_secs * 1000.0);
             let actual_ms = millis_round_u64(raw_dt * 1000.0);
-            json_events::emit_interval_slip(&mut log_file, interval_ms, actual_ms);
+            json_events::emit_interval_slip(&mut logger, interval_ms, actual_ms);
         }
 
         let dt = match apply_measured_dt(
@@ -352,14 +345,14 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
             args.max_dt,
             args.dt_clamp,
             args.quiet,
-            &mut log_file,
+            &mut logger,
         ) {
             MeasuredDt::Skip => {
                 handle_dt_skip_state_write(
                     session.on_dt_skipped(),
                     &session,
                     args.state_path.as_ref(),
-                    &mut log_file,
+                    &mut logger,
                     args.quiet,
                 );
                 continue;
@@ -376,12 +369,12 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
             Err(error) => {
                 pv_fail_count += 1;
                 eprintln!("PV read failed: {error}");
-                json_events::emit_pv_read_failure(&mut log_file, error.to_string(), args.safe_cv);
+                json_events::emit_pv_read_failure(&mut logger, error.to_string(), args.safe_cv);
                 write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
                 if let Some(limit) = args.fail_after
                     && pv_fail_count >= limit
                 {
-                    json_events::emit_pv_fail_after_reached(&mut log_file, pv_fail_count, limit);
+                    json_events::emit_pv_fail_after_reached(&mut logger, pv_fail_count, limit);
                     return Err(CliError::new(
                         2,
                         format!("exiting after {pv_fail_count} consecutive PV read failures"),
@@ -397,7 +390,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
             dt,
             &mut session,
             cv_sink.as_mut(),
-            &mut log_file,
+            &mut logger,
             &mut cv_fail_count,
         )?;
     }
@@ -414,7 +407,7 @@ fn run_loop_tick(
     dt: f64,
     session: &mut ControllerSession,
     cv_sink: &mut dyn CvSink,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     cv_fail_count: &mut u32,
 ) -> Result<(), CliError> {
     let scaled_pv = raw_pv * args.scale;
@@ -424,7 +417,7 @@ fn run_loop_tick(
             *cv_fail_count = 0;
 
             if let Some(reason) = outcome.d_term_skipped {
-                json_events::emit_d_term_skipped(log_file, reason, outcome.record.iter);
+                json_events::emit_d_term_skipped(logger, reason, outcome.record.iter);
             }
 
             if matches!(args.output_format, OutputFormat::Json)
@@ -433,11 +426,7 @@ fn run_loop_tick(
                 eprintln!("output write failed: {error}");
             }
 
-            if let Some(file) = log_file
-                && let Ok(json) = serde_json::to_string(&outcome.record)
-            {
-                let _ = writeln!(file, "{json}");
-            }
+            logger.write_iteration_line(&outcome.record);
 
             if args.verbose {
                 let r = &outcome.record;
@@ -451,7 +440,7 @@ fn run_loop_tick(
                 emit_state_write_failure(
                     session,
                     args.state_path.as_ref(),
-                    log_file,
+                    logger,
                     &error,
                     args.quiet,
                 );
@@ -461,7 +450,7 @@ fn run_loop_tick(
             *cv_fail_count += 1;
             let limit = args.cv_fail_after;
             eprintln!("CV write failed ({cv_fail_count}/{limit}): {error}");
-            json_events::emit_cv_write_failed(log_file, error.to_string(), *cv_fail_count);
+            json_events::emit_cv_write_failed(logger, error.to_string(), *cv_fail_count);
             if *cv_fail_count >= limit {
                 write_safe_cv(args.safe_cv, cv_sink, session);
                 return Err(CliError::new(
@@ -478,7 +467,7 @@ fn run_loop_tick(
 fn resolve_once_dt(
     session: &ControllerSession,
     args: &OnceArgs,
-    log: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> f64 {
     if args.dt_explicit {
         return args.dt;
@@ -489,7 +478,7 @@ fn resolve_once_dt(
     session
         .wall_clock_dt_since_state_update()
         .map_or(args.dt, |raw| {
-            clamp_once_wall_clock_dt(raw, args.min_dt, args.max_dt, log)
+            clamp_once_wall_clock_dt(raw, args.min_dt, args.max_dt, logger)
         })
 }
 
@@ -497,19 +486,19 @@ fn clamp_once_wall_clock_dt(
     raw: f64,
     min_dt: f64,
     max_dt: f64,
-    log: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> f64 {
     let raw = raw.max(0.0);
     if raw < min_dt {
         eprintln!("once: wall-clock dt {raw:.6}s below --min-dt {min_dt:.6}s — clamping to min_dt");
-        json_events::emit_dt_clamped(log, raw, min_dt);
+        json_events::emit_dt_clamped(logger, raw, min_dt);
         return min_dt;
     }
     if raw > max_dt {
         eprintln!(
             "once: wall-clock dt {raw:.6}s exceeds --max-dt {max_dt:.6}s — clamping to max_dt"
         );
-        json_events::emit_dt_clamped(log, raw, max_dt);
+        json_events::emit_dt_clamped(logger, raw, max_dt);
         return max_dt;
     }
     raw
@@ -524,7 +513,7 @@ fn sleep_with_socket(
     args: &mut LoopArgs,
     hold: &mut bool,
     shutdown: &AtomicBool,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) {
     loop {
         let now = Instant::now();
@@ -536,7 +525,7 @@ fn sleep_with_socket(
 
         for _ in 0..10 {
             match listener.try_service_one(|req| {
-                let (resp, effect) = handle_socket_request(&req, session, args, log_file);
+                let (resp, effect) = handle_socket_request(&req, session, args, logger);
                 match effect {
                     SocketSideEffect::Hold => *hold = true,
                     SocketSideEffect::Resume => *hold = false,

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -464,11 +464,7 @@ fn run_loop_tick(
     Ok(())
 }
 
-fn resolve_once_dt(
-    session: &ControllerSession,
-    args: &OnceArgs,
-    logger: &mut Logger,
-) -> f64 {
+fn resolve_once_dt(session: &ControllerSession, args: &OnceArgs, logger: &mut Logger) -> f64 {
     if args.dt_explicit {
         return args.dt;
     }
@@ -482,12 +478,7 @@ fn resolve_once_dt(
         })
 }
 
-fn clamp_once_wall_clock_dt(
-    raw: f64,
-    min_dt: f64,
-    max_dt: f64,
-    logger: &mut Logger,
-) -> f64 {
+fn clamp_once_wall_clock_dt(raw: f64, min_dt: f64, max_dt: f64, logger: &mut Logger) -> f64 {
     let raw = raw.max(0.0);
     if raw < min_dt {
         eprintln!("once: wall-clock dt {raw:.6}s below --min-dt {min_dt:.6}s — clamping to min_dt");

--- a/crates/pid-ctl/src/tune/export.rs
+++ b/crates/pid-ctl/src/tune/export.rs
@@ -1,17 +1,18 @@
 use crate::LoopArgs;
 use pid_ctl::app::ControllerSession;
+use pid_ctl::app::logger::Logger;
 use pid_ctl::json_events;
 use std::time::Duration;
 
 pub(in crate::tune) fn flush_shutdown(
     session: &mut ControllerSession,
     args: &LoopArgs,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) {
     if let Some(err) = session.force_flush() {
         eprintln!("state write failed at shutdown: {err}");
         if let Some(path) = &args.state_path {
-            json_events::emit_state_write_failed(log_file, path.clone(), err.to_string());
+            json_events::emit_state_write_failed(logger, path.clone(), err.to_string());
         }
     }
 }

--- a/crates/pid-ctl/src/tune/input.rs
+++ b/crates/pid-ctl/src/tune/input.rs
@@ -7,6 +7,7 @@ use crate::CliError;
 use crate::LoopArgs;
 use crossterm::event::{KeyCode, KeyModifiers};
 use pid_ctl::app::ControllerSession;
+use pid_ctl::app::logger::Logger;
 use pid_ctl::json_events;
 use pid_ctl_core::PidConfig;
 use std::time::{Duration, Instant};
@@ -49,17 +50,17 @@ pub(in crate::tune) fn handle_normal_key(
     args: &mut LoopArgs,
     key: crossterm::event::KeyEvent,
     full_argv: &[String],
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) {
     match key.code {
         KeyCode::Char('q') => {
             export_line_stderr(full_argv, args);
-            flush_shutdown(session, args, log_file);
+            flush_shutdown(session, args, logger);
             ui.quit = true;
         }
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             export_line_stderr(full_argv, args);
-            flush_shutdown(session, args, log_file);
+            flush_shutdown(session, args, logger);
             ui.quit = true;
         }
         KeyCode::Char('c') => {
@@ -74,7 +75,7 @@ pub(in crate::tune) fn handle_normal_key(
                 eprintln!("save failed: {err}");
             } else {
                 json_events::emit_gains_saved(
-                    log_file,
+                    logger,
                     ui.last_record.as_ref().map_or(0, |r| r.iter),
                 );
                 ui.status_flash = Some(("Saved".into(), Instant::now()));
@@ -105,8 +106,8 @@ pub(in crate::tune) fn handle_normal_key(
         }
         KeyCode::Up => ui.focus = ui.focus.prev(),
         KeyCode::Down => ui.focus = ui.focus.next(),
-        KeyCode::Left => adjust_focused_gain(ui, session, args, log_file, -1.0),
-        KeyCode::Right => adjust_focused_gain(ui, session, args, log_file, 1.0),
+        KeyCode::Left => adjust_focused_gain(ui, session, args, logger, -1.0),
+        KeyCode::Right => adjust_focused_gain(ui, session, args, logger, 1.0),
         KeyCode::Char('[') => {
             ui.step[ui.focus.idx()] = step_125_down(ui.step[ui.focus.idx()]);
         }
@@ -121,7 +122,7 @@ pub(in crate::tune) fn adjust_focused_gain(
     ui: &mut TuneUiState,
     session: &mut ControllerSession,
     args: &mut LoopArgs,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     sign: f64,
 ) {
     let step = ui.step[ui.focus.idx()] * sign;
@@ -136,7 +137,7 @@ pub(in crate::tune) fn adjust_focused_gain(
     ui.note_gain_change(args, session.config());
     let iter = ui.last_record.as_ref().map_or(0, |r| r.iter);
     let c = session.config();
-    json_events::emit_gains_changed(log_file, c.kp, c.ki, c.kd, c.setpoint, iter, "tui");
+    json_events::emit_gains_changed(logger, c.kp, c.ki, c.kd, c.setpoint, iter, "tui");
 }
 
 pub(in crate::tune) fn handle_command_key(
@@ -145,7 +146,7 @@ pub(in crate::tune) fn handle_command_key(
     args: &mut LoopArgs,
     key: crossterm::event::KeyEvent,
     full_argv: &[String],
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> Result<(), CliError> {
     match key.code {
         KeyCode::Esc => {
@@ -153,7 +154,7 @@ pub(in crate::tune) fn handle_command_key(
             ui.command_buf.clear();
         }
         KeyCode::Enter => {
-            run_command_line(ui, session, args, full_argv, log_file)?;
+            run_command_line(ui, session, args, full_argv, logger)?;
             ui.command_mode = false;
             ui.command_buf.clear();
         }
@@ -174,7 +175,7 @@ pub(in crate::tune) fn run_command_line(
     session: &mut ControllerSession,
     args: &mut LoopArgs,
     full_argv: &[String],
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
 ) -> Result<(), CliError> {
     let line = ui.command_buf.trim();
     let mut parts = line.split_whitespace();
@@ -183,7 +184,7 @@ pub(in crate::tune) fn run_command_line(
         "" => Ok(()),
         "quit" | "exit" => {
             export_line_stderr(full_argv, args);
-            flush_shutdown(session, args, log_file);
+            flush_shutdown(session, args, logger);
             ui.quit = true;
             Ok(())
         }
@@ -198,7 +199,7 @@ pub(in crate::tune) fn run_command_line(
             args.pid_config = session.config().clone();
             ui.note_gain_change(args, session.config());
             json_events::emit_gains_changed(
-                log_file,
+                logger,
                 v,
                 c.ki,
                 c.kd,
@@ -219,7 +220,7 @@ pub(in crate::tune) fn run_command_line(
             args.pid_config = session.config().clone();
             ui.note_gain_change(args, session.config());
             json_events::emit_gains_changed(
-                log_file,
+                logger,
                 c.kp,
                 v,
                 c.kd,
@@ -240,7 +241,7 @@ pub(in crate::tune) fn run_command_line(
             args.pid_config = session.config().clone();
             ui.note_gain_change(args, session.config());
             json_events::emit_gains_changed(
-                log_file,
+                logger,
                 c.kp,
                 c.ki,
                 v,
@@ -261,7 +262,7 @@ pub(in crate::tune) fn run_command_line(
             ui.note_gain_change(args, session.config());
             let c = session.config();
             json_events::emit_gains_changed(
-                log_file,
+                logger,
                 c.kp,
                 c.ki,
                 c.kd,
@@ -299,7 +300,7 @@ pub(in crate::tune) fn run_command_line(
                 eprintln!("save failed: {err}");
             } else {
                 json_events::emit_gains_saved(
-                    log_file,
+                    logger,
                     ui.last_record.as_ref().map_or(0, |r| r.iter),
                 );
                 ui.status_flash = Some(("Saved".into(), Instant::now()));

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -21,16 +21,17 @@ use input::{handle_command_key, handle_normal_key};
 use model::{TUNE_IDLE_DRAW_DEADLINE_NEAR, TUNE_IDLE_DRAW_MIN, TuneUiState};
 use pid_ctl::adapters::{CvSink, DryRunCvSink};
 use pid_ctl::app::adapters_build::{build_cv_sink, build_pv_source};
+use pid_ctl::app::logger::Logger;
 use pid_ctl::app::loop_runtime::{
     MeasuredDt, apply_measured_dt, emit_state_write_failure, handle_dt_skip_state_write,
-    open_log_optional, write_safe_cv,
+    write_safe_cv,
 };
 use pid_ctl::app::{ControllerSession, TickOutcome};
 use pid_ctl::json_events;
 use pid_ctl::schedule::next_deadline_after_tick;
 use ratatui::Terminal;
 use render::draw;
-use std::io::{self, Write};
+use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -40,7 +41,6 @@ use std::time::{Duration, Instant};
 // place — splitting it further would require passing state through many helper boundaries.
 #[allow(clippy::too_many_lines)]
 pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
-    let _suppress_structured_json_stderr = json_events::suppress_structured_json_stderr();
     let mut session = ControllerSession::new(args.session_config())
         .map_err(|e| CliError::config(e.to_string()))?;
     let cfg0 = session.config().clone();
@@ -56,15 +56,18 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
         .cv_sink
         .as_ref()
         .map(|cfg| build_cv_sink(cfg, args.cv_precision, args.cmd_timeout));
-    let mut log_file = open_log_optional(args.log_path.as_deref()).map_err(|e| {
-        CliError::new(
-            1,
-            format!(
-                "failed to open log file {}: {e}",
-                args.log_path.as_deref().unwrap().display()
-            ),
-        )
-    })?;
+    // Suppress stderr so JSON event lines don't interleave with the ratatui alternate-screen TUI.
+    let mut logger = Logger::open(args.log_path.as_deref())
+        .map_err(|e| {
+            CliError::new(
+                1,
+                format!(
+                    "failed to open log file {}: {e}",
+                    args.log_path.as_deref().unwrap().display()
+                ),
+            )
+        })?
+        .suppressed();
 
     // Bind socket listener when --socket is set.
     let socket_listener = if let Some(ref path) = args.socket_path {
@@ -103,7 +106,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
         loop {
             if shutdown.load(Ordering::Relaxed) || ui.quit {
                 export_line_stderr(full_argv, &args);
-                flush_shutdown(&mut session, &args, &mut log_file);
+                flush_shutdown(&mut session, &args, &mut logger);
                 return Ok(());
             }
 
@@ -132,7 +135,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                                 &mut args,
                                 key,
                                 full_argv,
-                                &mut log_file,
+                                &mut logger,
                             )?;
                         } else {
                             handle_normal_key(
@@ -141,7 +144,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                                 &mut args,
                                 key,
                                 full_argv,
-                                &mut log_file,
+                                &mut logger,
                             );
                         }
                     }
@@ -156,7 +159,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                 for _ in 0..10 {
                     match listener.try_service_one(|req| {
                         let (resp, effect) =
-                            handle_socket_request(&req, &mut session, &mut args, &mut log_file);
+                            handle_socket_request(&req, &mut session, &mut args, &mut logger);
                         match effect {
                             SocketSideEffect::Hold => ui.hold = true,
                             SocketSideEffect::Resume => ui.hold = false,
@@ -205,14 +208,14 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                 args.max_dt,
                 args.dt_clamp,
                 false, // tune is never quiet (tune and --quiet are mutually exclusive)
-                &mut log_file,
+                &mut logger,
             ) {
                 MeasuredDt::Skip => {
                     handle_dt_skip_state_write(
                         session.on_dt_skipped(),
                         &session,
                         args.state_path.as_ref(),
-                        &mut log_file,
+                        &mut logger,
                         false,
                     );
                     draw(
@@ -237,7 +240,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                 Err(error) => {
                     pv_fail_count += 1;
                     json_events::emit_pv_read_failure(
-                        &mut log_file,
+                        &mut logger,
                         error.to_string(),
                         args.safe_cv,
                     );
@@ -290,7 +293,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                             emit_state_write_failure(
                                 &session,
                                 args.state_path.as_ref(),
-                                &mut log_file,
+                                &mut logger,
                                 &e,
                                 false,
                             );
@@ -322,7 +325,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                     dt,
                     &mut session,
                     active,
-                    &mut log_file,
+                    &mut logger,
                     &mut cv_fail_count,
                 ) {
                     Ok(Some(outcome)) => {
@@ -368,7 +371,7 @@ fn tune_tick(
     dt: f64,
     session: &mut ControllerSession,
     cv_sink: &mut dyn CvSink,
-    log_file: &mut Option<std::fs::File>,
+    logger: &mut Logger,
     cv_fail_count: &mut u32,
 ) -> Result<Option<TickOutcome>, CliError> {
     let scaled_pv = raw_pv * args.scale;
@@ -378,21 +381,17 @@ fn tune_tick(
             *cv_fail_count = 0;
 
             if let Some(reason) = outcome.d_term_skipped {
-                json_events::emit_d_term_skipped(log_file, reason, outcome.record.iter);
+                json_events::emit_d_term_skipped(logger, reason, outcome.record.iter);
             }
 
             if matches!(args.output_format, OutputFormat::Json) {
                 let _ = print_iteration_json(&outcome.record);
             }
 
-            if let Some(file) = log_file.as_mut()
-                && let Ok(json) = serde_json::to_string(&outcome.record)
-            {
-                let _ = writeln!(file, "{json}");
-            }
+            logger.write_iteration_line(&outcome.record);
 
             if let Some(ref error) = outcome.state_write_failed {
-                emit_state_write_failure(session, args.state_path.as_ref(), log_file, error, false);
+                emit_state_write_failure(session, args.state_path.as_ref(), logger, error, false);
             }
 
             Ok(Some(outcome))
@@ -400,7 +399,7 @@ fn tune_tick(
         Err(error) => {
             *cv_fail_count += 1;
             let limit = args.cv_fail_after;
-            json_events::emit_cv_write_failed(log_file, error.to_string(), *cv_fail_count);
+            json_events::emit_cv_write_failed(logger, error.to_string(), *cv_fail_count);
             if *cv_fail_count >= limit {
                 write_safe_cv(args.safe_cv, cv_sink, session);
                 return Err(CliError::new(

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -239,11 +239,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                 }
                 Err(error) => {
                     pv_fail_count += 1;
-                    json_events::emit_pv_read_failure(
-                        &mut logger,
-                        error.to_string(),
-                        args.safe_cv,
-                    );
+                    json_events::emit_pv_read_failure(&mut logger, error.to_string(), args.safe_cv);
                     if let Some(ref mut sink) = hardware {
                         write_safe_cv(args.safe_cv, sink.as_mut(), &mut session);
                     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements Phase 2 (#8 + #7) from the [refactor plan](../blob/claude/codebase-structure-review-GnkEb/planning/refactor-plan.md), which depends on Phase 1 (already merged).

- **#8** — Introduce `app/logger.rs`: concrete `Logger` struct owning `file: Option<File>` and `suppress_stderr: bool`. Replace the 22 call sites that threaded `&mut Option<&mut File>` across `loop_runtime`, `socket_dispatch`, `main`, `tune/mod`, `tune/input`, and `tune/export`.
- **#7** — Remove the process-global `SUPPRESS_STRUCTURED_JSON_STDERR: AtomicBool` and its RAII guard from `json_events.rs`. `tune::run` now constructs `Logger::open(...).suppressed()` instead, eliminating the latent race if threading is ever introduced.
- Remove `open_log_optional` from `loop_runtime`; callers use `Logger::open`.
- Update `json_events` macro and hand-written emit functions to take `&mut Logger`.
- Replace scattered `if let Some(file) = log_file.as_mut() && let Ok(json)...` patterns with `logger.write_iteration_line(record)`.

## Test plan

- [x] All 284 existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Integration tests (`tests/req/*.rs`) pass byte-for-byte — no CLI surface change

https://claude.ai/code/session_01RYx93giGBzGo39ei8CBeBU
EOF
)