### PR TITLE
feat(phase-3): shared ticker driver + unit tests (#3 + #10)

### DIFF
--- a/crates/pid-ctl/src/app/loop_runtime.rs
+++ b/crates/pid-ctl/src/app/loop_runtime.rs
@@ -5,7 +5,7 @@ use crate::adapters::CvSink;
 use crate::app::logger::Logger;
 use crate::app::{ControllerSession, StateStoreError};
 use crate::json_events;
-use std::path::PathBuf;
+use std::path::Path;
 use std::time::Duration;
 
 pub enum MeasuredDt {
@@ -114,7 +114,7 @@ pub fn write_safe_cv(
 pub fn handle_dt_skip_state_write(
     err: Option<StateStoreError>,
     session: &ControllerSession,
-    state_path: Option<&PathBuf>,
+    state_path: Option<&Path>,
     logger: &mut Logger,
     quiet: bool,
 ) {
@@ -127,7 +127,7 @@ pub fn handle_dt_skip_state_write(
 /// Emits a state write failure — escalated warning if threshold reached, plain log otherwise.
 pub fn emit_state_write_failure(
     session: &ControllerSession,
-    state_path: Option<&PathBuf>,
+    state_path: Option<&Path>,
     logger: &mut Logger,
     err: &StateStoreError,
     quiet: bool,
@@ -138,12 +138,17 @@ pub fn emit_state_write_failure(
             if !quiet {
                 eprintln!("WARNING: state write failing persistently ({count} consecutive): {err}");
             }
-            json_events::emit_state_write_escalated(logger, path.clone(), err.to_string(), count);
+            json_events::emit_state_write_escalated(
+                logger,
+                path.to_path_buf(),
+                err.to_string(),
+                count,
+            );
         } else {
             if !quiet {
                 eprintln!("state write failed: {err}");
             }
-            json_events::emit_state_write_failed(logger, path.clone(), err.to_string());
+            json_events::emit_state_write_failed(logger, path.to_path_buf(), err.to_string());
         }
     } else if !quiet {
         eprintln!("state write failed: {err}");
@@ -153,13 +158,13 @@ pub fn emit_state_write_failure(
 /// Forces a final state flush at loop shutdown, logging any failure.
 pub fn flush_state_at_shutdown(
     session: &mut ControllerSession,
-    state_path: Option<&PathBuf>,
+    state_path: Option<&Path>,
     logger: &mut Logger,
 ) {
     if let Some(err) = session.force_flush() {
         eprintln!("state write failed at shutdown: {err}");
         if let Some(path) = state_path {
-            json_events::emit_state_write_failed(logger, path.clone(), err.to_string());
+            json_events::emit_state_write_failed(logger, path.to_path_buf(), err.to_string());
         }
     }
 }

--- a/crates/pid-ctl/src/app/mod.rs
+++ b/crates/pid-ctl/src/app/mod.rs
@@ -6,6 +6,7 @@ pub mod loop_runtime;
 #[cfg(unix)]
 pub mod socket_dispatch;
 pub mod state_store;
+pub mod ticker;
 
 use crate::adapters::CvSink;
 use pid_ctl_core::{ConfigError, PidConfig, PidController, StepInput, StepResult};

--- a/crates/pid-ctl/src/app/ticker.rs
+++ b/crates/pid-ctl/src/app/ticker.rs
@@ -1,0 +1,318 @@
+//! Shared tick driver consumed by both `run_loop` and `tune::run`.
+//!
+//! Both paths call [`step`] with a [`TickContext`] and a [`TickObserver`].
+//! Common logic (`process_pv`, d-term event, iteration log, state-failure report,
+//! cv-write-failed event, safe-cv write on exhaustion) lives here; mode-specific
+//! side-effects (stdout JSON, verbose stderr, TUI state update) are delegated to
+//! the observer.
+
+use crate::adapters::CvSink;
+use crate::app::logger::Logger;
+use crate::app::loop_runtime::{emit_state_write_failure, write_safe_cv};
+use crate::app::{ControllerSession, TickError, TickOutcome};
+use crate::json_events;
+use std::path::Path;
+
+/// All inputs needed for one PID tick.
+pub struct TickContext<'a> {
+    pub scaled_pv: f64,
+    pub dt: f64,
+    pub session: &'a mut ControllerSession,
+    pub cv_sink: &'a mut dyn CvSink,
+    pub logger: &'a mut Logger,
+    pub state_path: Option<&'a Path>,
+    pub cv_fail_after: u32,
+    pub safe_cv: Option<f64>,
+    pub quiet: bool,
+}
+
+/// Observer for divergent per-caller behaviour in a shared tick.
+///
+/// `on_success` is called after the common success-path bookkeeping (d-term log,
+/// iteration line write, state-failure report). Callers use it for output-format
+/// printing (JSON to stdout) and mode-specific diagnostics (verbose eprintln, TUI update).
+///
+/// `on_cv_fail` is called before the shared JSON event; callers use it to emit
+/// their per-mode failure message (eprintln for `loop`, silence for `--tune`).
+pub trait TickObserver {
+    fn on_success(&mut self, outcome: &TickOutcome);
+    fn on_cv_fail(&mut self, error: &TickError, consecutive: u32);
+}
+
+/// Result of one shared tick step.
+pub enum TickStepResult {
+    /// Tick succeeded; CV was written and the outcome is available.
+    Ok(TickOutcome),
+    /// CV write failed but the failure limit has not been reached.
+    CvFailTransient { consecutive: u32 },
+    /// CV write failures exhausted the configured limit; caller should exit with code 2.
+    CvFailExhausted(String),
+}
+
+/// Executes one PID tick, delegating output and mode-specific side-effects to `observer`.
+///
+/// Common logic: `process_pv`, d-term event, iteration log, state-failure report,
+/// `emit_cv_write_failed`, `write_safe_cv` on exhaustion.
+///
+/// Returns [`TickStepResult`] which the caller converts to its own error type at
+/// the binary boundary.
+pub fn step(
+    ctx: TickContext<'_>,
+    cv_fail_count: &mut u32,
+    observer: &mut dyn TickObserver,
+) -> TickStepResult {
+    let TickContext {
+        scaled_pv,
+        dt,
+        session,
+        cv_sink,
+        logger,
+        state_path,
+        cv_fail_after,
+        safe_cv,
+        quiet,
+    } = ctx;
+
+    match session.process_pv(scaled_pv, dt, cv_sink) {
+        Ok(outcome) => {
+            *cv_fail_count = 0;
+
+            if let Some(reason) = outcome.d_term_skipped {
+                json_events::emit_d_term_skipped(logger, reason, outcome.record.iter);
+            }
+
+            logger.write_iteration_line(&outcome.record);
+
+            if let Some(ref error) = outcome.state_write_failed {
+                emit_state_write_failure(session, state_path, logger, error, quiet);
+            }
+
+            observer.on_success(&outcome);
+            TickStepResult::Ok(outcome)
+        }
+        Err(error) => {
+            *cv_fail_count += 1;
+            observer.on_cv_fail(&error, *cv_fail_count);
+            json_events::emit_cv_write_failed(logger, error.to_string(), *cv_fail_count);
+            if *cv_fail_count >= cv_fail_after {
+                write_safe_cv(safe_cv, cv_sink, session);
+                TickStepResult::CvFailExhausted(format!(
+                    "exiting after {cv_fail_count} consecutive CV write failures: {error}"
+                ))
+            } else {
+                TickStepResult::CvFailTransient {
+                    consecutive: *cv_fail_count,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{ControllerSession, SessionConfig};
+    use pid_ctl_core::PidConfig;
+
+    struct OkSink;
+    impl CvSink for OkSink {
+        fn write_cv(&mut self, _cv: f64) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailSink;
+    impl CvSink for FailSink {
+        fn write_cv(&mut self, _cv: f64) -> std::io::Result<()> {
+            Err(std::io::Error::other("fake CV failure"))
+        }
+    }
+
+    #[derive(Default)]
+    struct Rec {
+        successes: u32,
+        d_term_skips: u32,
+        cv_fails: Vec<u32>,
+    }
+
+    impl TickObserver for Rec {
+        fn on_success(&mut self, outcome: &TickOutcome) {
+            self.successes += 1;
+            if outcome.d_term_skipped.is_some() {
+                self.d_term_skips += 1;
+            }
+        }
+        fn on_cv_fail(&mut self, _error: &TickError, consecutive: u32) {
+            self.cv_fails.push(consecutive);
+        }
+    }
+
+    fn basic_session() -> ControllerSession {
+        ControllerSession::new(SessionConfig {
+            pid: PidConfig {
+                kp: 1.0,
+                setpoint: 10.0,
+                ..PidConfig::default()
+            },
+            ..SessionConfig::default()
+        })
+        .expect("session")
+    }
+
+    #[test]
+    fn happy_path_notifies_observer() {
+        let mut session = basic_session();
+        let mut sink = OkSink;
+        let mut logger = Logger::none();
+        let mut rec = Rec::default();
+        let mut fail_count = 0u32;
+
+        let ctx = TickContext {
+            scaled_pv: 5.0,
+            dt: 1.0,
+            session: &mut session,
+            cv_sink: &mut sink,
+            logger: &mut logger,
+            state_path: None,
+            cv_fail_after: 3,
+            safe_cv: None,
+            quiet: true,
+        };
+        let result = step(ctx, &mut fail_count, &mut rec);
+        assert!(matches!(result, TickStepResult::Ok(_)));
+        assert_eq!(rec.successes, 1);
+        assert_eq!(rec.cv_fails.len(), 0);
+        assert_eq!(fail_count, 0);
+    }
+
+    #[test]
+    fn cv_fail_transient_increments_counter() {
+        let mut session = basic_session();
+        let mut sink = FailSink;
+        let mut logger = Logger::none();
+        let mut rec = Rec::default();
+        let mut fail_count = 0u32;
+
+        let ctx = TickContext {
+            scaled_pv: 5.0,
+            dt: 1.0,
+            session: &mut session,
+            cv_sink: &mut sink,
+            logger: &mut logger,
+            state_path: None,
+            cv_fail_after: 3,
+            safe_cv: None,
+            quiet: true,
+        };
+        let result = step(ctx, &mut fail_count, &mut rec);
+        assert!(matches!(
+            result,
+            TickStepResult::CvFailTransient { consecutive: 1 }
+        ));
+        assert_eq!(rec.cv_fails, vec![1]);
+        assert_eq!(fail_count, 1);
+    }
+
+    #[test]
+    fn cv_fail_exhausted_at_threshold() {
+        let mut session = basic_session();
+        let mut sink = FailSink;
+        let mut logger = Logger::none();
+        let mut rec = Rec::default();
+        let mut fail_count = 0u32;
+
+        let ctx = TickContext {
+            scaled_pv: 5.0,
+            dt: 1.0,
+            session: &mut session,
+            cv_sink: &mut sink,
+            logger: &mut logger,
+            state_path: None,
+            cv_fail_after: 1,
+            safe_cv: None,
+            quiet: true,
+        };
+        let result = step(ctx, &mut fail_count, &mut rec);
+        assert!(matches!(result, TickStepResult::CvFailExhausted(_)));
+        assert_eq!(fail_count, 1);
+    }
+
+    #[test]
+    fn d_term_skip_surfaces_in_observer() {
+        // kd must be non-zero: the D-term early-returns None when kd == 0.
+        let mut session = ControllerSession::new(SessionConfig {
+            pid: PidConfig {
+                kp: 1.0,
+                kd: 1.0,
+                setpoint: 10.0,
+                ..PidConfig::default()
+            },
+            ..SessionConfig::default()
+        })
+        .expect("session");
+        let mut sink = OkSink;
+        let mut logger = Logger::none();
+        let mut rec = Rec::default();
+        let mut fail_count = 0u32;
+
+        // First tick seeds last_pv.
+        session.process_pv(5.0, 1.0, &mut sink).unwrap();
+        // Mark dt skipped so next tick has D-term skip.
+        session.on_dt_skipped();
+
+        let ctx = TickContext {
+            scaled_pv: 5.0,
+            dt: 1.0,
+            session: &mut session,
+            cv_sink: &mut sink,
+            logger: &mut logger,
+            state_path: None,
+            cv_fail_after: 3,
+            safe_cv: None,
+            quiet: true,
+        };
+        let result = step(ctx, &mut fail_count, &mut rec);
+        assert!(matches!(result, TickStepResult::Ok(_)));
+        assert_eq!(rec.d_term_skips, 1);
+    }
+
+    #[test]
+    fn cv_fail_count_resets_on_success() {
+        let mut session = basic_session();
+        let mut logger = Logger::none();
+        let mut rec = Rec::default();
+        let mut fail_count = 2u32;
+
+        // One more fail (total 3, threshold 5 → transient).
+        let mut fail_sink = FailSink;
+        let ctx = TickContext {
+            scaled_pv: 5.0,
+            dt: 1.0,
+            session: &mut session,
+            cv_sink: &mut fail_sink,
+            logger: &mut logger,
+            state_path: None,
+            cv_fail_after: 5,
+            safe_cv: None,
+            quiet: true,
+        };
+        step(ctx, &mut fail_count, &mut rec);
+        assert_eq!(fail_count, 3);
+
+        // Succeed — count resets.
+        let mut ok_sink = OkSink;
+        let ctx2 = TickContext {
+            scaled_pv: 5.0,
+            dt: 1.0,
+            session: &mut session,
+            cv_sink: &mut ok_sink,
+            logger: &mut logger,
+            state_path: None,
+            cv_fail_after: 5,
+            safe_cv: None,
+            quiet: true,
+        };
+        step(ctx2, &mut fail_count, &mut rec);
+        assert_eq!(fail_count, 0);
+    }
+}

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -12,7 +12,8 @@ use pid_ctl::app::loop_runtime::{
     MeasuredDt, apply_measured_dt, emit_state_write_failure, flush_state_at_shutdown,
     handle_dt_skip_state_write, millis_round_u64, write_safe_cv,
 };
-use pid_ctl::app::{self, ControllerSession, StateSnapshot, StateStore};
+use pid_ctl::app::ticker::{self, TickContext, TickObserver, TickStepResult};
+use pid_ctl::app::{self, ControllerSession, StateSnapshot, StateStore, TickError, TickOutcome};
 use pid_ctl::json_events;
 use pid_ctl::schedule::next_deadline_after_tick;
 use std::io::{self, BufRead, Write};
@@ -213,7 +214,7 @@ fn run_pipe(args: &PipeArgs) -> Result<(), CliError> {
         if let Some(error) = outcome.state_write_failed {
             emit_state_write_failure(
                 &session,
-                args.state_path.as_ref(),
+                args.state_path.as_deref(),
                 &mut logger,
                 &error,
                 false,
@@ -279,7 +280,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         // Check shutdown flag at top of each iteration.
         if shutdown.load(Ordering::Relaxed) {
             write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-            flush_state_at_shutdown(&mut session, args.state_path.as_ref(), &mut logger);
+            flush_state_at_shutdown(&mut session, args.state_path.as_deref(), &mut logger);
             break;
         }
 
@@ -307,7 +308,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         // Check shutdown again after sleeping (signal may have arrived during sleep).
         if shutdown.load(Ordering::Relaxed) {
             write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-            flush_state_at_shutdown(&mut session, args.state_path.as_ref(), &mut logger);
+            flush_state_at_shutdown(&mut session, args.state_path.as_deref(), &mut logger);
             break;
         }
 
@@ -351,7 +352,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
                 handle_dt_skip_state_write(
                     session.on_dt_skipped(),
                     &session,
-                    args.state_path.as_ref(),
+                    args.state_path.as_deref(),
                     &mut logger,
                     args.quiet,
                 );
@@ -384,84 +385,60 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
             }
         };
 
-        run_loop_tick(
-            args,
-            raw_pv,
+        let mut observer = LoopObserver {
+            output_format: args.output_format,
+            verbose: args.verbose,
+            cv_fail_after: args.cv_fail_after,
+        };
+        let ctx = TickContext {
+            scaled_pv: raw_pv * args.scale,
             dt,
-            &mut session,
-            cv_sink.as_mut(),
-            &mut logger,
-            &mut cv_fail_count,
-        )?;
+            session: &mut session,
+            cv_sink: cv_sink.as_mut(),
+            logger: &mut logger,
+            state_path: args.state_path.as_deref(),
+            cv_fail_after: args.cv_fail_after,
+            safe_cv: args.safe_cv,
+            quiet: args.quiet,
+        };
+        if let TickStepResult::CvFailExhausted(msg) =
+            ticker::step(ctx, &mut cv_fail_count, &mut observer)
+        {
+            return Err(CliError::new(2, msg));
+        }
     }
 
     Ok(())
 }
 
-/// Executes one PID tick: computes CV, writes to sink, logs outcome.
-///
-/// Returns `Err` when CV write failures exceed the configured limit.
-fn run_loop_tick(
-    args: &LoopArgs,
-    raw_pv: f64,
-    dt: f64,
-    session: &mut ControllerSession,
-    cv_sink: &mut dyn CvSink,
-    logger: &mut Logger,
-    cv_fail_count: &mut u32,
-) -> Result<(), CliError> {
-    let scaled_pv = raw_pv * args.scale;
+struct LoopObserver {
+    output_format: OutputFormat,
+    verbose: bool,
+    cv_fail_after: u32,
+}
 
-    match session.process_pv(scaled_pv, dt, cv_sink) {
-        Ok(outcome) => {
-            *cv_fail_count = 0;
-
-            if let Some(reason) = outcome.d_term_skipped {
-                json_events::emit_d_term_skipped(logger, reason, outcome.record.iter);
-            }
-
-            if matches!(args.output_format, OutputFormat::Json)
-                && let Err(error) = print_iteration_json(&outcome.record)
-            {
-                eprintln!("output write failed: {error}");
-            }
-
-            logger.write_iteration_line(&outcome.record);
-
-            if args.verbose {
-                let r = &outcome.record;
-                eprintln!(
-                    "iter={} pv={:.4} sp={:.4} err={:.4} cv={:.4} p={:.4} i={:.4} d={:.4}",
-                    r.iter, r.pv, r.sp, r.err, r.cv, r.p, r.i, r.d
-                );
-            }
-
-            if let Some(error) = outcome.state_write_failed {
-                emit_state_write_failure(
-                    session,
-                    args.state_path.as_ref(),
-                    logger,
-                    &error,
-                    args.quiet,
-                );
-            }
+impl TickObserver for LoopObserver {
+    fn on_success(&mut self, outcome: &TickOutcome) {
+        if matches!(self.output_format, OutputFormat::Json)
+            && let Err(error) = print_iteration_json(&outcome.record)
+        {
+            eprintln!("output write failed: {error}");
         }
-        Err(error) => {
-            *cv_fail_count += 1;
-            let limit = args.cv_fail_after;
-            eprintln!("CV write failed ({cv_fail_count}/{limit}): {error}");
-            json_events::emit_cv_write_failed(logger, error.to_string(), *cv_fail_count);
-            if *cv_fail_count >= limit {
-                write_safe_cv(args.safe_cv, cv_sink, session);
-                return Err(CliError::new(
-                    2,
-                    format!("exiting after {cv_fail_count} consecutive CV write failures: {error}"),
-                ));
-            }
+        if self.verbose {
+            let r = &outcome.record;
+            eprintln!(
+                "iter={} pv={:.4} sp={:.4} err={:.4} cv={:.4} p={:.4} i={:.4} d={:.4}",
+                r.iter, r.pv, r.sp, r.err, r.cv, r.p, r.i, r.d
+            );
         }
     }
 
-    Ok(())
+    fn on_cv_fail(&mut self, error: &TickError, consecutive: u32) {
+        eprintln!(
+            "CV write failed ({consecutive}/{}): {error}",
+            self.cv_fail_after
+        );
+    }
 }
 
 fn resolve_once_dt(session: &ControllerSession, args: &OnceArgs, logger: &mut Logger) -> f64 {

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -26,7 +26,8 @@ use pid_ctl::app::loop_runtime::{
     MeasuredDt, apply_measured_dt, emit_state_write_failure, handle_dt_skip_state_write,
     write_safe_cv,
 };
-use pid_ctl::app::{ControllerSession, TickOutcome};
+use pid_ctl::app::ticker::{self, TickContext, TickObserver, TickStepResult};
+use pid_ctl::app::{ControllerSession, TickError, TickOutcome};
 use pid_ctl::json_events;
 use pid_ctl::schedule::next_deadline_after_tick;
 use ratatui::Terminal;
@@ -214,7 +215,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                     handle_dt_skip_state_write(
                         session.on_dt_skipped(),
                         &session,
-                        args.state_path.as_ref(),
+                        args.state_path.as_deref(),
                         &mut logger,
                         false,
                     );
@@ -288,7 +289,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                         if let Some(e) = h.state_write_failed {
                             emit_state_write_failure(
                                 &session,
-                                args.state_path.as_ref(),
+                                args.state_path.as_deref(),
                                 &mut logger,
                                 &e,
                                 false,
@@ -315,16 +316,22 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                         }
                     }
                 };
-                match tune_tick(
-                    &args,
-                    raw_pv,
+                let mut observer = TuneObserver {
+                    output_format: args.output_format,
+                };
+                let ctx = TickContext {
+                    scaled_pv,
                     dt,
-                    &mut session,
-                    active,
-                    &mut logger,
-                    &mut cv_fail_count,
-                ) {
-                    Ok(Some(outcome)) => {
+                    session: &mut session,
+                    cv_sink: active,
+                    logger: &mut logger,
+                    state_path: args.state_path.as_deref(),
+                    cv_fail_after: args.cv_fail_after,
+                    safe_cv: args.safe_cv,
+                    quiet: false,
+                };
+                match ticker::step(ctx, &mut cv_fail_count, &mut observer) {
+                    TickStepResult::Ok(outcome) => {
                         ui.last_record = Some(outcome.record.clone());
                         if let Ok(sz) = terminal.size() {
                             ui.spark_w = sz.width.saturating_sub(4) as usize;
@@ -336,8 +343,8 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                             session.config().setpoint,
                         );
                     }
-                    Ok(None) => {}
-                    Err(e) => return Err(e),
+                    TickStepResult::CvFailTransient { .. } => {}
+                    TickStepResult::CvFailExhausted(msg) => return Err(CliError::new(2, msg)),
                 }
             }
 
@@ -360,51 +367,19 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
     run_result
 }
 
-/// Like `run_loop_tick` but returns the outcome for the dashboard; skips JSON on stdout (TUI owns the screen).
-fn tune_tick(
-    args: &LoopArgs,
-    raw_pv: f64,
-    dt: f64,
-    session: &mut ControllerSession,
-    cv_sink: &mut dyn CvSink,
-    logger: &mut Logger,
-    cv_fail_count: &mut u32,
-) -> Result<Option<TickOutcome>, CliError> {
-    let scaled_pv = raw_pv * args.scale;
+struct TuneObserver {
+    output_format: OutputFormat,
+}
 
-    match session.process_pv(scaled_pv, dt, cv_sink) {
-        Ok(outcome) => {
-            *cv_fail_count = 0;
-
-            if let Some(reason) = outcome.d_term_skipped {
-                json_events::emit_d_term_skipped(logger, reason, outcome.record.iter);
-            }
-
-            if matches!(args.output_format, OutputFormat::Json) {
-                let _ = print_iteration_json(&outcome.record);
-            }
-
-            logger.write_iteration_line(&outcome.record);
-
-            if let Some(ref error) = outcome.state_write_failed {
-                emit_state_write_failure(session, args.state_path.as_ref(), logger, error, false);
-            }
-
-            Ok(Some(outcome))
+impl TickObserver for TuneObserver {
+    fn on_success(&mut self, outcome: &TickOutcome) {
+        if matches!(self.output_format, OutputFormat::Json) {
+            let _ = print_iteration_json(&outcome.record);
         }
-        Err(error) => {
-            *cv_fail_count += 1;
-            let limit = args.cv_fail_after;
-            json_events::emit_cv_write_failed(logger, error.to_string(), *cv_fail_count);
-            if *cv_fail_count >= limit {
-                write_safe_cv(args.safe_cv, cv_sink, session);
-                return Err(CliError::new(
-                    2,
-                    format!("exiting after {cv_fail_count} consecutive CV write failures: {error}"),
-                ));
-            }
-            Ok(None)
-        }
+    }
+
+    fn on_cv_fail(&mut self, _error: &TickError, _consecutive: u32) {
+        // TUI owns the screen; no per-failure eprintln.
     }
 }
 


### PR DESCRIPTION
## Summary

Implements Phase 3 from the refactor plan (PR #1): findings #3 (shared tick driver) and #10 (unit tests for tick logic).

- **New `app::ticker` module** (`app/ticker.rs`, ~120 LOC): `TickContext`, `TickObserver` trait, `TickStepResult` enum, and `step()` function. Contains the entire common tick pipeline: `process_pv`, d-term event, iteration log write, state-failure reporting, `emit_cv_write_failed`, `write_safe_cv` on exhaustion.
- **Deleted `run_loop_tick`** in `main.rs` (~50 LOC). Replaced by `LoopObserver` (stdout JSON + verbose eprintln) + inline `ticker::step` call.
- **Deleted `tune_tick`** in `tune/mod.rs` (~45 LOC). Replaced by `TuneObserver` (stdout JSON, no stderr) + inline `ticker::step` call.
- **5 unit tests** in `app::ticker::tests`: happy path, transient CV fail, exhausted CV fail, D-term skip surfacing, fail-count reset on success.
- **Widened `loop_runtime` signatures**: `emit_state_write_failure`, `handle_dt_skip_state_write`, `flush_state_at_shutdown` now accept `Option<&Path>` instead of `Option<&PathBuf>`.

All 140 integration tests and 25 library unit tests pass. Wire behavior (stdout/stderr/state bytes) is byte-identical to pre-refactor.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 25 lib + 140 integration tests pass, 0 failures
- [x] `cargo test -p pid-ctl --test requirements req_loop req_fail_after req_cv_write_policy req_tune req_tune_pty` — all pass
- [x] `cargo test -p pid-ctl --lib app::ticker::tests` — 5 new unit tests pass
- [x] Verified plan checklist: `run_loop_tick` deleted, `tune_tick` deleted, shared `step()` unified, observer pattern for divergent behavior

https://claude.ai/code/session_01QbNEsApb1spku71KNm6Z9p