### PR TITLE
feat(phase-6): keep tune in binary; finalize binary-module boundary

### DIFF
--- a/crates/pid-ctl/src/cli/mod.rs
+++ b/crates/pid-ctl/src/cli/mod.rs
@@ -1,15 +1,19 @@
 mod error;
+mod output;
 mod parse;
 mod raw;
 mod types;
 pub(crate) mod user_set;
 
 pub(crate) use error::CliError;
+pub(crate) use output::print_iteration_json;
+#[cfg(feature = "tui")]
+pub(crate) use parse::parse_duration_flag;
 #[cfg(unix)]
 pub(crate) use parse::{get_socket_path, parse_set_args};
 pub(crate) use parse::{
-    get_state_path, parse_duration_flag, parse_f64_value, parse_loop, parse_once, parse_pipe,
-    parse_status_flags, resolve_pv,
+    get_state_path, parse_f64_value, parse_loop, parse_once, parse_pipe, parse_status_flags,
+    resolve_pv,
 };
 pub(crate) use raw::{Cli, SubCommand};
 #[cfg(unix)]

--- a/crates/pid-ctl/src/cli/output.rs
+++ b/crates/pid-ctl/src/cli/output.rs
@@ -1,0 +1,14 @@
+use super::error::CliError;
+use pid_ctl::app::IterationRecord;
+use std::io::{self, Write};
+
+/// Serialize `record` as a single JSON line to stdout.
+///
+/// Returns a [`CliError`] if serialization or the stdout write fails.
+pub(crate) fn print_iteration_json(record: &IterationRecord) -> Result<(), CliError> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer(&mut handle, record)
+        .map_err(|error| CliError::new(3, format!("failed to serialize JSON output: {error}")))?;
+    writeln!(handle).map_err(|error| CliError::new(1, format!("stdout write failed: {error}")))
+}

--- a/crates/pid-ctl/src/cli/parse.rs
+++ b/crates/pid-ctl/src/cli/parse.rs
@@ -171,29 +171,29 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
     let tune = false;
 
     #[cfg(feature = "tui")]
-    let tune_history = raw.tune_history;
+    let tune_history: usize = raw.tune_history.unwrap_or(60).max(1);
     #[cfg(not(feature = "tui"))]
-    let tune_history: Option<usize> = None;
+    let tune_history: usize = 60;
 
     #[cfg(feature = "tui")]
-    let tune_step_kp = raw.tune_step_kp;
+    let tune_step_kp: f64 = raw.tune_step_kp.unwrap_or(0.1);
     #[cfg(not(feature = "tui"))]
-    let tune_step_kp: Option<f64> = None;
+    let tune_step_kp: f64 = 0.1;
 
     #[cfg(feature = "tui")]
-    let tune_step_ki = raw.tune_step_ki;
+    let tune_step_ki: f64 = raw.tune_step_ki.unwrap_or(0.01);
     #[cfg(not(feature = "tui"))]
-    let tune_step_ki: Option<f64> = None;
+    let tune_step_ki: f64 = 0.01;
 
     #[cfg(feature = "tui")]
-    let tune_step_kd = raw.tune_step_kd;
+    let tune_step_kd: f64 = raw.tune_step_kd.unwrap_or(0.05);
     #[cfg(not(feature = "tui"))]
-    let tune_step_kd: Option<f64> = None;
+    let tune_step_kd: f64 = 0.05;
 
     #[cfg(feature = "tui")]
-    let tune_step_sp = raw.tune_step_sp;
+    let tune_step_sp: f64 = raw.tune_step_sp.unwrap_or(0.1);
     #[cfg(not(feature = "tui"))]
-    let tune_step_sp: Option<f64> = None;
+    let tune_step_sp: f64 = 0.1;
 
     let output_format: OutputFormat = raw.common.format.clone().into();
 
@@ -329,11 +329,11 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
         state_write_interval,
         state_fail_after: raw.common.state_fail_after.unwrap_or(10),
         tune,
-        tune_history: tune_history.unwrap_or(60).max(1),
-        tune_step_kp: tune_step_kp.unwrap_or(0.1),
-        tune_step_ki: tune_step_ki.unwrap_or(0.01),
-        tune_step_kd: tune_step_kd.unwrap_or(0.05),
-        tune_step_sp: tune_step_sp.unwrap_or(0.1),
+        tune_history,
+        tune_step_kp,
+        tune_step_ki,
+        tune_step_kd,
+        tune_step_sp,
         units: raw.common.units.clone(),
         quiet: raw.common.quiet,
         verbose: raw.common.verbose,

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -511,14 +511,6 @@ fn sleep_with_socket(
     }
 }
 
-pub(crate) fn print_iteration_json(record: &pid_ctl::app::IterationRecord) -> Result<(), CliError> {
-    let stdout = io::stdout();
-    let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, record)
-        .map_err(|error| CliError::new(3, format!("failed to serialize JSON output: {error}")))?;
-    writeln!(handle).map_err(|error| CliError::new(1, format!("stdout write failed: {error}")))
-}
-
 fn run_status(state_path: &std::path::Path) -> Result<(), CliError> {
     let store = StateStore::new(state_path);
     let snapshot = store

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -1,4 +1,22 @@
 //! Interactive `loop --tune` dashboard (`pid-ctl_plan.md` § `--tune`).
+//!
+//! # Why `tune` lives in the binary crate
+//!
+//! Phase 6 of the refactor plan evaluated moving this module into `pid_ctl` (the library).
+//! The recommendation — keep it here — stands for three reasons that remain true after
+//! phases 0–5:
+//!
+//! 1. **Terminal ownership**: the event loop drives raw-mode stdout via ratatui/crossterm,
+//!    which is a binary-level concern, not a library API.
+//! 2. **Binary error type**: every fallible path returns [`crate::CliError`], which is
+//!    intentionally `pub(crate)` inside the binary; the library uses typed errors that
+//!    `main.rs` converts at the boundary.
+//! 3. **Dependency hygiene**: pulling `ratatui`/`crossterm` into the library would force
+//!    the `tui` feature onto every downstream consumer of `pid_ctl`.
+//!
+//! If a future need arises (e.g. an embedder wants headless tick-loop access), the pure
+//! data types (`TuneUiState`, history, model) can be extracted to the library at that
+//! point without invalidating this decision for the TUI-specific logic.
 
 mod model;
 


### PR DESCRIPTION
## Summary

Phase 6 of the refactor plan (PR #1): evaluate tune migration, implement the "keep in binary" recommendation.

- **Decision recorded**: Added a module-level doc comment to `tune/mod.rs` explaining the three reasons tune stays in the binary crate (terminal ownership, `CliError` dependency, TUI feature hygiene).
- **Binary boundary finalized**: Moved `print_iteration_json` from `main.rs` into a new `cli/output.rs`. `main.rs` now has zero `pub(crate)` definitions beyond re-exports — completing the phase-1 goal of reducing `main.rs` to a pure dispatcher.
- **Pre-existing no-TUI lint fixed**: Gated `parse_duration_flag` re-export behind `#[cfg(feature = "tui")]`; resolved five `unnecessary_literal_unwrap` errors in `cli/parse.rs` by folding defaults directly into the `#[cfg(not(feature = "tui"))]` bindings (instead of `Option::None.unwrap_or(default)`).

## Verification against plan

> Phase 6 (optional): evaluate tune migration (recommend: keep in binary)

✅ Evaluated: tune depends on `CliError`, `LoopArgs`, `OutputFormat` (all binary-only) and owns raw-mode terminal control — moving it would impose ratatui/crossterm on library consumers.
✅ Decision implemented and documented.
✅ `cargo clippy --workspace --all-targets -- -D warnings` passes (both with and without `--no-default-features`).
✅ `cargo fmt --all -- --check` passes.
✅ `cargo test --workspace` — all tests pass.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p pid-ctl --test requirements`

https://claude.ai/code/session_01LU36MsHXXCVaois5nM4dYL