### PR TITLE
feat(phase-6): move print_iteration_json to cli/output.rs

### DIFF
--- a/crates/pid-ctl/src/cli/mod.rs
+++ b/crates/pid-ctl/src/cli/mod.rs
@@ -1,10 +1,12 @@
 mod error;
+mod output;
 mod parse;
 mod raw;
 mod types;
 pub(crate) mod user_set;
 
 pub(crate) use error::CliError;
+pub(crate) use output::print_iteration_json;
 #[cfg(unix)]
 pub(crate) use parse::{get_socket_path, parse_set_args};
 pub(crate) use parse::{

--- a/crates/pid-ctl/src/cli/output.rs
+++ b/crates/pid-ctl/src/cli/output.rs
@@ -1,0 +1,10 @@
+use crate::CliError;
+use std::io::Write;
+
+pub(crate) fn print_iteration_json(record: &pid_ctl::app::IterationRecord) -> Result<(), CliError> {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer(&mut handle, record)
+        .map_err(|error| CliError::new(3, format!("failed to serialize JSON output: {error}")))?;
+    writeln!(handle).map_err(|error| CliError::new(1, format!("stdout write failed: {error}")))
+}

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -511,14 +511,6 @@ fn sleep_with_socket(
     }
 }
 
-pub(crate) fn print_iteration_json(record: &pid_ctl::app::IterationRecord) -> Result<(), CliError> {
-    let stdout = io::stdout();
-    let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, record)
-        .map_err(|error| CliError::new(3, format!("failed to serialize JSON output: {error}")))?;
-    writeln!(handle).map_err(|error| CliError::new(1, format!("stdout write failed: {error}")))
-}
-
 fn run_status(state_path: &std::path::Path) -> Result<(), CliError> {
     let store = StateStore::new(state_path);
     let snapshot = store


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Moves `print_iteration_json` from `main.rs` into the new `crates/pid-ctl/src/cli/output.rs` module
- Exports it from `cli/mod.rs` alongside the other CLI helpers
- Eliminates the last `main.rs` coupling that `tune` had

## Phase 6 evaluation result: keep tune in binary

This implements the Phase 6 decision from the refactor plan (PR #1). The plan recommended keeping `tune` in the binary crate rather than migrating it to the library, for three reasons:

1. `tune` owns stdout/stderr terminal control — a binary concern
2. It uses `crate::CliError`, the binary's own error type
3. Moving it would impose the `tui` feature (ratatui/crossterm) on library consumers

The precondition for formalising this decision was that `tune` should no longer reach back into `main.rs` function bodies. After phases 1–5, one coupling remained: `print_iteration_json` was still defined directly in `main.rs` as `pub(crate)`. This PR moves it to `cli/output.rs`.

After this change, all of tune's `crate::` imports resolve through `cli/` modules:
- `crate::CliError` → `cli/error.rs`
- `crate::LoopArgs` → `cli/types.rs`
- `crate::OutputFormat` → `cli/types.rs`
- `crate::print_iteration_json` → `cli/output.rs` ← new

No behaviour changes. All existing integration tests pass byte-for-byte.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (311 tests, 0 failures)

https://claude.ai/code/session_01KFRL8C9nJduA4hcWDWnSBJ
EOF
)