### PR TITLE
chore(phase-6): doc comment + no-tui lint fixes (salvaged from PR #7)

### DIFF
--- a/crates/pid-ctl/src/cli/mod.rs
+++ b/crates/pid-ctl/src/cli/mod.rs
@@ -7,11 +7,13 @@ pub(crate) mod user_set;
 
 pub(crate) use error::CliError;
 pub(crate) use output::print_iteration_json;
+#[cfg(feature = "tui")]
+pub(crate) use parse::parse_duration_flag;
 #[cfg(unix)]
 pub(crate) use parse::{get_socket_path, parse_set_args};
 pub(crate) use parse::{
-    get_state_path, parse_duration_flag, parse_f64_value, parse_loop, parse_once, parse_pipe,
-    parse_status_flags, resolve_pv,
+    get_state_path, parse_f64_value, parse_loop, parse_once, parse_pipe, parse_status_flags,
+    resolve_pv,
 };
 pub(crate) use raw::{Cli, SubCommand};
 #[cfg(unix)]

--- a/crates/pid-ctl/src/cli/parse.rs
+++ b/crates/pid-ctl/src/cli/parse.rs
@@ -171,29 +171,29 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
     let tune = false;
 
     #[cfg(feature = "tui")]
-    let tune_history = raw.tune_history;
+    let tune_history: usize = raw.tune_history.unwrap_or(60).max(1);
     #[cfg(not(feature = "tui"))]
-    let tune_history: Option<usize> = None;
+    let tune_history: usize = 60;
 
     #[cfg(feature = "tui")]
-    let tune_step_kp = raw.tune_step_kp;
+    let tune_step_kp: f64 = raw.tune_step_kp.unwrap_or(0.1);
     #[cfg(not(feature = "tui"))]
-    let tune_step_kp: Option<f64> = None;
+    let tune_step_kp: f64 = 0.1;
 
     #[cfg(feature = "tui")]
-    let tune_step_ki = raw.tune_step_ki;
+    let tune_step_ki: f64 = raw.tune_step_ki.unwrap_or(0.01);
     #[cfg(not(feature = "tui"))]
-    let tune_step_ki: Option<f64> = None;
+    let tune_step_ki: f64 = 0.01;
 
     #[cfg(feature = "tui")]
-    let tune_step_kd = raw.tune_step_kd;
+    let tune_step_kd: f64 = raw.tune_step_kd.unwrap_or(0.05);
     #[cfg(not(feature = "tui"))]
-    let tune_step_kd: Option<f64> = None;
+    let tune_step_kd: f64 = 0.05;
 
     #[cfg(feature = "tui")]
-    let tune_step_sp = raw.tune_step_sp;
+    let tune_step_sp: f64 = raw.tune_step_sp.unwrap_or(0.1);
     #[cfg(not(feature = "tui"))]
-    let tune_step_sp: Option<f64> = None;
+    let tune_step_sp: f64 = 0.1;
 
     let output_format: OutputFormat = raw.common.format.clone().into();
 
@@ -329,11 +329,11 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
         state_write_interval,
         state_fail_after: raw.common.state_fail_after.unwrap_or(10),
         tune,
-        tune_history: tune_history.unwrap_or(60).max(1),
-        tune_step_kp: tune_step_kp.unwrap_or(0.1),
-        tune_step_ki: tune_step_ki.unwrap_or(0.01),
-        tune_step_kd: tune_step_kd.unwrap_or(0.05),
-        tune_step_sp: tune_step_sp.unwrap_or(0.1),
+        tune_history,
+        tune_step_kp,
+        tune_step_ki,
+        tune_step_kd,
+        tune_step_sp,
         units: raw.common.units.clone(),
         quiet: raw.common.quiet,
         verbose: raw.common.verbose,

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -1,4 +1,22 @@
 //! Interactive `loop --tune` dashboard (`pid-ctl_plan.md` § `--tune`).
+//!
+//! # Why `tune` lives in the binary crate
+//!
+//! Phase 6 of the refactor plan evaluated moving this module into `pid_ctl` (the library).
+//! The recommendation — keep it here — stands for three reasons that remain true after
+//! phases 0–5:
+//!
+//! 1. **Terminal ownership**: the event loop drives raw-mode stdout via ratatui/crossterm,
+//!    which is a binary-level concern, not a library API.
+//! 2. **Binary error type**: every fallible path returns [`crate::CliError`], which is
+//!    intentionally `pub(crate)` inside the binary; the library uses typed errors that
+//!    `main.rs` converts at the boundary.
+//! 3. **Dependency hygiene**: pulling `ratatui`/`crossterm` into the library would force
+//!    the `tui` feature onto every downstream consumer of `pid_ctl`.
+//!
+//! If a future need arises (e.g. an embedder wants headless tick-loop access), the pure
+//! data types (`TuneUiState`, history, model) can be extracted to the library at that
+//! point without invalidating this decision for the TUI-specific logic.
 
 mod model;
 


### PR DESCRIPTION
## Summary

PR #8 merged the core phase-6 change (moving `print_iteration_json` to `cli/output.rs`). PR #7 was a parallel implementation of the same phase that had three additional improvements not in #8. This PR salvages them.

### Changes

**`tune/mod.rs`** — module-level doc comment recording the three reasons tune stays in the binary crate (terminal ownership, `CliError` dependency, TUI feature hygiene) so the decision is documented at the source.

**`cli/mod.rs`** — gate `parse_duration_flag` re-export behind `#[cfg(feature = "tui")]`. Only `tune/input.rs` needs it at the crate root; `cli/raw.rs` imports it directly from `parse`, so this is safe and eliminates a spurious unused-import warning in the no-tui build.

**`cli/parse.rs`** — fold `unwrap_or(default)` directly into the `#[cfg(not(feature = "tui"))]` bindings for `tune_history` and `tune_step_*`. Previously the no-tui path bound `None` and then the struct initialiser called `.unwrap_or(default)`, which clippy flags as `unnecessary_literal_unwrap`. Resolves 5 pre-existing lint errors.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` ✅ (previously had 6 errors)
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅

https://claude.ai/code/session_01KFRL8C9nJduA4hcWDWnSBJ