### PR TITLE
refactor: replace unreachable!() in apply_gain_param with typed GainParam enum

### DIFF
--- a/crates/pid-ctl/src/app/socket_dispatch.rs
+++ b/crates/pid-ctl/src/app/socket_dispatch.rs
@@ -108,19 +108,29 @@ pub fn handle_socket_request(
     }
 }
 
-/// Apply a single gain parameter (kp/ki/kd) to the session and emit the change event.
+/// The three gain parameters that `apply_gain_param` can update.
+///
+/// Using a dedicated enum rather than `&str` makes `apply_gain_param`'s match
+/// exhaustive, eliminating the need for an `unreachable!()` arm on `_`.
+#[derive(Clone, Copy)]
+enum GainParam {
+    Kp,
+    Ki,
+    Kd,
+}
+
+/// Apply a single gain parameter to the session and emit the change event.
 /// Returns the old value. Gains are ordered [kp, ki, kd] throughout.
 fn apply_gain_param(
-    param: &str,
+    param: GainParam,
     value: f64,
     session: &mut ControllerSession,
     logger: &mut Logger,
 ) -> f64 {
     let idx = match param {
-        "kp" => 0usize,
-        "ki" => 1,
-        "kd" => 2,
-        _ => unreachable!("apply_gain_param called with non-gain param: {param}"),
+        GainParam::Kp => 0usize,
+        GainParam::Ki => 1,
+        GainParam::Kd => 2,
     };
     let cfg = session.config();
     let mut gains = [cfg.kp, cfg.ki, cfg.kd];
@@ -161,7 +171,12 @@ fn handle_socket_set(
 
     match param {
         "kp" | "ki" | "kd" => {
-            let old = apply_gain_param(param, value, session, logger);
+            let gain = match param {
+                "kp" => GainParam::Kp,
+                "ki" => GainParam::Ki,
+                _ => GainParam::Kd,
+            };
+            let old = apply_gain_param(gain, value, session, logger);
             (
                 Response::Set {
                     ok: true,


### PR DESCRIPTION
## Summary

- `apply_gain_param` matched on `&str` and used `unreachable!()` on the `_` arm, relying on the caller to never pass a non-gain parameter string. If that invariant breaks during future edits, the panic surfaces at runtime — not at compile time.
- Introduce a private `GainParam { Kp, Ki, Kd }` enum. `handle_socket_set` converts the matched string to `GainParam` before calling `apply_gain_param`, making `apply_gain_param`'s match exhaustive with no `_` arm required. The type system now enforces the invariant.
- No wire protocol change — `param: String` in `Request::Set` and all response shapes are unchanged. Existing `ErrorUnknownParam` path is preserved.

## Test plan

- [ ] All 21 socket integration tests pass (`req_socket`)
- [ ] `cargo clippy -- -D warnings` clean (no new suppressions)
- [ ] CI passes

https://claude.ai/code/session_01SZYVxfXRYS5MMQwZR1f96s