### PR TITLE
refactor: extract LoopRuntimeConfig from LoopArgs (Issue 3)

### DIFF
--- a/crates/pid-ctl/src/app/loop_runtime.rs
+++ b/crates/pid-ctl/src/app/loop_runtime.rs
@@ -13,17 +13,24 @@ pub enum MeasuredDt {
     Use(f64),
 }
 
-/// Trait over the mutable loop-configuration state that socket commands and the interval command
-/// need to inspect and update without depending on the concrete [`super::super::cli::types::LoopArgs`] type.
+/// Trait over the mutable runtime loop configuration.
+///
+/// Used by socket dispatch and the interval command to inspect and update loop parameters
+/// without depending on the concrete `LoopRuntimeConfig` type. The `maybe_set_*` methods
+/// update a field only when the user did not supply an explicit CLI value; if the user
+/// provided an explicit value it is never overridden at runtime.
 pub trait LoopControls {
     fn interval(&self) -> Duration;
     fn set_interval(&mut self, d: Duration);
     fn max_dt(&self) -> f64;
-    fn set_max_dt_unless_explicit(&mut self, v: f64);
+    /// Sets `max_dt` only when the user did not explicitly provide `--max-dt` on the CLI.
+    fn maybe_set_max_dt(&mut self, v: f64);
     fn pv_stdin_timeout(&self) -> Duration;
-    fn set_pv_stdin_timeout_unless_explicit(&mut self, d: Duration);
+    /// Sets `pv_stdin_timeout` only when the user did not explicitly provide `--pv-stdin-timeout`.
+    fn maybe_set_pv_stdin_timeout(&mut self, d: Duration);
     fn state_write_interval(&self) -> Option<Duration>;
-    fn set_state_write_interval_unless_explicit(&mut self, d: Option<Duration>);
+    /// Sets `state_write_interval` only when the user did not explicitly provide `--state-write-interval`.
+    fn maybe_set_state_write_interval(&mut self, d: Option<Duration>);
 }
 
 /// Applies a new loop interval at runtime, updating derived defaults (`max_dt`,
@@ -35,10 +42,10 @@ pub fn apply_runtime_interval(
 ) {
     controls.set_interval(new_interval);
     let s = new_interval.as_secs_f64();
-    controls.set_max_dt_unless_explicit((s * 3.0_f64).clamp(0.01, 60.0));
-    controls.set_pv_stdin_timeout_unless_explicit(new_interval);
+    controls.maybe_set_max_dt((s * 3.0_f64).clamp(0.01, 60.0));
+    controls.maybe_set_pv_stdin_timeout(new_interval);
     let min_flush = Duration::from_millis(100);
-    controls.set_state_write_interval_unless_explicit(Some(new_interval.max(min_flush)));
+    controls.maybe_set_state_write_interval(Some(new_interval.max(min_flush)));
     session.set_flush_interval(controls.state_write_interval());
 }
 

--- a/crates/pid-ctl/src/cli/mod.rs
+++ b/crates/pid-ctl/src/cli/mod.rs
@@ -18,4 +18,6 @@ pub(crate) use parse::{
 pub(crate) use raw::{Cli, SubCommand};
 #[cfg(unix)]
 pub(crate) use raw::{SetRawArgs, SocketOnlyArgs};
-pub(crate) use types::{LoopArgs, OnceArgs, OutputFormat, PipeArgs, StatusFlags};
+pub(crate) use types::{
+    LoopArgs, LoopRuntimeConfig, OnceArgs, OutputFormat, PipeArgs, StatusFlags,
+};

--- a/crates/pid-ctl/src/cli/parse.rs
+++ b/crates/pid-ctl/src/cli/parse.rs
@@ -1,7 +1,7 @@
 use super::raw::{LoopRawArgs, OnceRawArgs, PipeRawArgs, StatusRawArgs};
 use super::types::{
-    CvSinkConfig, LoopArgs, OnceArgs, OutputFormat, PidFlags, PipeArgs, PvSourceConfig, SetArgs,
-    StatusFlags,
+    CvSinkConfig, LoopArgs, LoopRuntimeConfig, OnceArgs, OutputFormat, PidFlags, PipeArgs,
+    PvSourceConfig, SetArgs, StatusFlags,
 };
 use super::user_set::UserSet;
 use crate::CliError;
@@ -297,8 +297,18 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
     #[cfg(unix)]
     let socket_mode = raw.socket_mode.unwrap_or(0o600);
 
+    let max_dt = raw
+        .common
+        .max_dt
+        .map_or_else(|| UserSet::Default(max_dt_default), UserSet::Explicit);
+
     Ok(LoopArgs {
-        interval,
+        runtime: LoopRuntimeConfig {
+            interval,
+            max_dt,
+            pv_stdin_timeout,
+            state_write_interval,
+        },
         pv_source,
         cv_sink,
         pid_config,
@@ -317,16 +327,10 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
             .common
             .min_dt
             .map_or_else(|| UserSet::Default(0.01), UserSet::Explicit),
-        max_dt: raw
-            .common
-            .max_dt
-            .map_or_else(|| UserSet::Default(max_dt_default), UserSet::Explicit),
         dt_clamp: raw.common.dt_clamp,
         log_path: raw.common.log.clone(),
         dry_run: raw.dry_run,
-        pv_stdin_timeout,
         verify_cv: raw.cv.verify_cv,
-        state_write_interval,
         state_fail_after: raw.common.state_fail_after.unwrap_or(10),
         tune,
         tune_history,

--- a/crates/pid-ctl/src/cli/types.rs
+++ b/crates/pid-ctl/src/cli/types.rs
@@ -93,10 +93,57 @@ impl PipeArgs {
     }
 }
 
+/// The four loop parameters that socket commands may update at runtime.
+///
+/// Separated from [`LoopArgs`] so that the mutable runtime surface is explicit: only fields
+/// in this struct can change after the loop starts. `maybe_set_*` methods honour user-explicit
+/// CLI values — they are no-ops when the user already provided a flag.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct LoopRuntimeConfig {
+    pub(crate) interval: Duration,
+    pub(crate) max_dt: UserSet<f64>,
+    pub(crate) pv_stdin_timeout: UserSet<Duration>,
+    pub(crate) state_write_interval: UserSet<Option<Duration>>,
+}
+
+impl LoopControls for LoopRuntimeConfig {
+    fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    fn set_interval(&mut self, d: Duration) {
+        self.interval = d;
+    }
+
+    fn max_dt(&self) -> f64 {
+        *self.max_dt.value()
+    }
+
+    fn maybe_set_max_dt(&mut self, v: f64) {
+        self.max_dt.set_if_default(v);
+    }
+
+    fn pv_stdin_timeout(&self) -> Duration {
+        *self.pv_stdin_timeout.value()
+    }
+
+    fn maybe_set_pv_stdin_timeout(&mut self, d: Duration) {
+        self.pv_stdin_timeout.set_if_default(d);
+    }
+
+    fn state_write_interval(&self) -> Option<Duration> {
+        *self.state_write_interval.value()
+    }
+
+    fn maybe_set_state_write_interval(&mut self, d: Option<Duration>) {
+        self.state_write_interval.set_if_default(d);
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct LoopArgs {
-    pub(crate) interval: Duration,
+    pub(crate) runtime: LoopRuntimeConfig,
     pub(crate) pv_source: PvSourceConfig,
     pub(crate) cv_sink: Option<CvSinkConfig>,
     pub(crate) pid_config: PidConfig,
@@ -112,13 +159,10 @@ pub(crate) struct LoopArgs {
     pub(crate) cv_fail_after: u32,
     pub(crate) fail_after: Option<u32>,
     pub(crate) min_dt: UserSet<f64>,
-    pub(crate) max_dt: UserSet<f64>,
     pub(crate) dt_clamp: bool,
     pub(crate) log_path: Option<PathBuf>,
     pub(crate) dry_run: bool,
-    pub(crate) pv_stdin_timeout: UserSet<Duration>,
     pub(crate) verify_cv: bool,
-    pub(crate) state_write_interval: UserSet<Option<Duration>>,
     pub(crate) state_fail_after: u32,
     pub(crate) tune: bool,
     pub(crate) tune_history: usize,
@@ -142,7 +186,7 @@ impl LoopArgs {
             pid: self.pid_config.clone(),
             state_store: self.state_path.clone().map(StateStore::new),
             reset_accumulator: self.reset_accumulator,
-            flush_interval: *self.state_write_interval.value(),
+            flush_interval: self.runtime.state_write_interval(),
             state_fail_after: self.state_fail_after,
         }
     }
@@ -159,38 +203,4 @@ pub(crate) struct StatusFlags {
     pub(crate) state_path: Option<PathBuf>,
     #[cfg(unix)]
     pub(crate) socket_path: Option<PathBuf>,
-}
-
-impl LoopControls for LoopArgs {
-    fn interval(&self) -> Duration {
-        self.interval
-    }
-
-    fn set_interval(&mut self, d: Duration) {
-        self.interval = d;
-    }
-
-    fn max_dt(&self) -> f64 {
-        *self.max_dt.value()
-    }
-
-    fn set_max_dt_unless_explicit(&mut self, v: f64) {
-        self.max_dt.set_if_default(v);
-    }
-
-    fn pv_stdin_timeout(&self) -> Duration {
-        *self.pv_stdin_timeout.value()
-    }
-
-    fn set_pv_stdin_timeout_unless_explicit(&mut self, d: Duration) {
-        self.pv_stdin_timeout.set_if_default(d);
-    }
-
-    fn state_write_interval(&self) -> Option<Duration> {
-        *self.state_write_interval.value()
-    }
-
-    fn set_state_write_interval_unless_explicit(&mut self, d: Option<Duration>) {
-        self.state_write_interval.set_if_default(d);
-    }
 }

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -9,7 +9,7 @@ use pid_ctl::adapters::{CvSink, DryRunCvSink, StdoutCvSink};
 use pid_ctl::app::adapters_build::{build_cv_sink, build_pv_source};
 use pid_ctl::app::logger::Logger;
 use pid_ctl::app::loop_runtime::{
-    MeasuredDt, apply_measured_dt, emit_state_write_failure, flush_state_at_shutdown,
+    LoopControls, MeasuredDt, apply_measured_dt, emit_state_write_failure, flush_state_at_shutdown,
     handle_dt_skip_state_write, millis_round_u64, write_safe_cv,
 };
 use pid_ctl::app::ticker::{self, TickContext, TickObserver, TickStepResult};
@@ -232,7 +232,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
     let mut pv_source = build_pv_source(
         &args.pv_source,
         args.pv_cmd_timeout,
-        *args.pv_stdin_timeout.value(),
+        args.runtime.pv_stdin_timeout(),
     );
     let mut cv_sink: Box<dyn CvSink> = if args.dry_run {
         Box::new(DryRunCvSink)
@@ -273,7 +273,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
     })
     .expect("signal handler");
 
-    let mut next_deadline = Instant::now() + args.interval;
+    let mut next_deadline = Instant::now() + args.runtime.interval;
     let mut last_tick = Instant::now();
     let mut cv_fail_count: u32 = 0;
     let mut pv_fail_count: u32 = 0;
@@ -296,7 +296,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
                     next_deadline,
                     listener,
                     &mut session,
-                    args,
+                    &mut args.runtime,
                     &mut hold,
                     &shutdown,
                     &mut logger,
@@ -317,7 +317,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
 
         let now = Instant::now();
         let tick_deadline = next_deadline;
-        next_deadline = next_deadline_after_tick(tick_deadline, args.interval, now);
+        next_deadline = next_deadline_after_tick(tick_deadline, args.runtime.interval, now);
 
         // Hold mode: skip PID computation, keep servicing socket.
         if hold {
@@ -329,7 +329,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         last_tick = now;
 
         // Interval slip (plan: Reliability §10 — tick longer than configured `--interval`).
-        let interval_secs = args.interval.as_secs_f64();
+        let interval_secs = args.runtime.interval.as_secs_f64();
         if raw_dt > interval_secs {
             if !args.quiet {
                 eprintln!(
@@ -346,7 +346,7 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         let dt = match apply_measured_dt(
             raw_dt,
             *args.min_dt.value(),
-            *args.max_dt.value(),
+            args.runtime.max_dt(),
             args.dt_clamp,
             args.quiet,
             &mut logger,
@@ -481,7 +481,7 @@ fn sleep_with_socket(
     until: Instant,
     listener: &pid_ctl::socket::SocketListener,
     session: &mut ControllerSession,
-    args: &mut LoopArgs,
+    runtime: &mut LoopRuntimeConfig,
     hold: &mut bool,
     shutdown: &AtomicBool,
     logger: &mut Logger,
@@ -496,7 +496,7 @@ fn sleep_with_socket(
 
         for _ in 0..10 {
             match listener.try_service_one(|req| {
-                let (resp, effect) = handle_socket_request(&req, session, args, logger);
+                let (resp, effect) = handle_socket_request(&req, session, runtime, logger);
                 match effect {
                     SocketSideEffect::Hold => *hold = true,
                     SocketSideEffect::Resume => *hold = false,

--- a/crates/pid-ctl/src/tune/export.rs
+++ b/crates/pid-ctl/src/tune/export.rs
@@ -45,7 +45,14 @@ pub(in crate::tune) fn is_export_tunable_flag(s: &str) -> bool {
 
 pub(in crate::tune) fn build_export_line(full_argv: &[String], args: &LoopArgs) -> String {
     let c = &args.pid_config;
-    build_export_line_values(full_argv, c.setpoint, c.kp, c.ki, c.kd, args.interval)
+    build_export_line_values(
+        full_argv,
+        c.setpoint,
+        c.kp,
+        c.ki,
+        c.kd,
+        args.runtime.interval,
+    )
 }
 
 pub(in crate::tune) fn build_export_line_values(

--- a/crates/pid-ctl/src/tune/input.rs
+++ b/crates/pid-ctl/src/tune/input.rs
@@ -277,7 +277,11 @@ pub(in crate::tune) fn run_command_line(
                 .next()
                 .ok_or_else(|| CliError::config("interval requires a duration"))?;
             let new_interval = crate::parse_duration_flag("--interval", dur_s)?;
-            pid_ctl::app::loop_runtime::apply_runtime_interval(session, args, new_interval);
+            pid_ctl::app::loop_runtime::apply_runtime_interval(
+                session,
+                &mut args.runtime,
+                new_interval,
+            );
             Ok(())
         }
         "reset" => {

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -41,8 +41,8 @@ use pid_ctl::adapters::{CvSink, DryRunCvSink};
 use pid_ctl::app::adapters_build::{build_cv_sink, build_pv_source};
 use pid_ctl::app::logger::Logger;
 use pid_ctl::app::loop_runtime::{
-    MeasuredDt, apply_measured_dt, emit_state_write_failure, handle_dt_skip_state_write,
-    write_safe_cv,
+    LoopControls, MeasuredDt, apply_measured_dt, emit_state_write_failure,
+    handle_dt_skip_state_write, write_safe_cv,
 };
 use pid_ctl::app::ticker::{self, TickContext, TickObserver, TickStepResult};
 use pid_ctl::app::{ControllerSession, TickError, TickOutcome};
@@ -72,7 +72,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
     let mut pv_source = build_pv_source(
         &args.pv_source,
         args.pv_cmd_timeout,
-        *args.pv_stdin_timeout.value(),
+        args.runtime.pv_stdin_timeout(),
     );
     let mut hardware: Option<Box<dyn CvSink>> = args
         .cv_sink
@@ -115,8 +115,8 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
     let mut terminal =
         Terminal::new(backend).map_err(|e| CliError::new(1, format!("terminal: {e}")))?;
 
-    let mut next_deadline = Instant::now() + args.interval;
-    let mut last_interval = args.interval;
+    let mut next_deadline = Instant::now() + args.runtime.interval;
+    let mut last_interval = args.runtime.interval;
     let mut last_tick = Instant::now();
     let mut last_idle_draw = Instant::now()
         .checked_sub(TUNE_IDLE_DRAW_MIN)
@@ -180,8 +180,12 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                 use pid_ctl::app::socket_dispatch::{SocketSideEffect, handle_socket_request};
                 for _ in 0..10 {
                     match listener.try_service_one(|req| {
-                        let (resp, effect) =
-                            handle_socket_request(&req, &mut session, &mut args, &mut logger);
+                        let (resp, effect) = handle_socket_request(
+                            &req,
+                            &mut session,
+                            &mut args.runtime,
+                            &mut logger,
+                        );
                         match effect {
                             SocketSideEffect::Hold => ui.hold = true,
                             SocketSideEffect::Resume => ui.hold = false,
@@ -195,13 +199,13 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
                 }
             }
 
-            if args.interval != last_interval {
-                last_interval = args.interval;
-                next_deadline = Instant::now() + args.interval;
+            if args.runtime.interval != last_interval {
+                last_interval = args.runtime.interval;
+                next_deadline = Instant::now() + args.runtime.interval;
             }
 
             let now = Instant::now();
-            let interval_secs = args.interval.as_secs_f64();
+            let interval_secs = args.runtime.interval.as_secs_f64();
             if now < next_deadline {
                 let until = next_deadline.saturating_duration_since(now);
                 let should_idle_draw = had_terminal_event
@@ -215,7 +219,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
             }
 
             let tick_deadline = next_deadline;
-            next_deadline = next_deadline_after_tick(tick_deadline, args.interval, now);
+            next_deadline = next_deadline_after_tick(tick_deadline, args.runtime.interval, now);
             let raw_dt = now.duration_since(last_tick).as_secs_f64();
             last_tick = now;
 
@@ -227,7 +231,7 @@ pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
             let dt = match apply_measured_dt(
                 raw_dt,
                 *args.min_dt.value(),
-                *args.max_dt.value(),
+                args.runtime.max_dt(),
                 args.dt_clamp,
                 false, // tune is never quiet (tune and --quiet are mutually exclusive)
                 &mut logger,

--- a/crates/pid-ctl/src/tune/render.rs
+++ b/crates/pid-ctl/src/tune/render.rs
@@ -498,7 +498,12 @@ pub(in crate::tune) fn render_frame(
     if ui.command_mode {
         use ratatui::style::Modifier;
         use ratatui::widgets::Clear;
-        let hint = command_mode_hint(&ui.command_buf, cfg, args.interval, args.units.as_deref());
+        let hint = command_mode_hint(
+            &ui.command_buf,
+            cfg,
+            args.runtime.interval,
+            args.units.as_deref(),
+        );
         let area = centered_rect(88, 18, f.area());
         let block = Block::default()
             .borders(Borders::ALL)

--- a/crates/pid-ctl/src/tune/tests.rs
+++ b/crates/pid-ctl/src/tune/tests.rs
@@ -484,7 +484,12 @@ fn test_pid_config() -> pid_ctl_core::PidConfig {
 
 fn test_loop_args(config: pid_ctl_core::PidConfig) -> super::LoopArgs {
     super::LoopArgs {
-        interval: Duration::from_secs(1),
+        runtime: crate::LoopRuntimeConfig {
+            interval: Duration::from_secs(1),
+            max_dt: crate::cli::user_set::UserSet::Default(2.0),
+            pv_stdin_timeout: crate::cli::user_set::UserSet::Default(Duration::from_secs(5)),
+            state_write_interval: crate::cli::user_set::UserSet::Default(None),
+        },
         pv_source: pid_ctl::app::adapters_build::PvSourceConfig::Literal(0.0),
         cv_sink: None,
         pid_config: config,
@@ -500,13 +505,10 @@ fn test_loop_args(config: pid_ctl_core::PidConfig) -> super::LoopArgs {
         cv_fail_after: 3,
         fail_after: None,
         min_dt: crate::cli::user_set::UserSet::Default(0.5),
-        max_dt: crate::cli::user_set::UserSet::Default(2.0),
         dt_clamp: false,
         log_path: None,
         dry_run: true,
-        pv_stdin_timeout: crate::cli::user_set::UserSet::Default(Duration::from_secs(5)),
         verify_cv: false,
-        state_write_interval: crate::cli::user_set::UserSet::Default(None),
         state_fail_after: 3,
         tune: true,
         tune_history: 60,


### PR DESCRIPTION
## Summary

- Extracts the four runtime-mutable fields from `LoopArgs` into a new `LoopRuntimeConfig` struct that implements `LoopControls`
- `LoopArgs` now has `pub(crate) runtime: LoopRuntimeConfig`; all socket-dispatch mutation goes through `args.runtime`
- Renames `set_*_unless_explicit` trait methods to `maybe_set_*` — same semantics, semantics now documented in the method comment rather than encoded in the method name

## Motivation

`LoopArgs` previously served double duty: it held immutable parsed CLI args AND was the `LoopControls` implementor that socket dispatch mutated at runtime. This made the mutable runtime surface implicit and scattered across a 30+ field struct. The `_unless_explicit` suffix on trait methods leaked the `UserSet<T>` implementation detail into the public trait API.

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Socket integration tests in `tests/req/req_socket.rs` pass unchanged

https://claude.ai/code/session_01SZYVxfXRYS5MMQwZR1f96s

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZYVxfXRYS5MMQwZR1f96s)_