### PR TITLE
chore: add curated "good taste" lints to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,21 @@ ratatui = "0.30"
 crossterm = "0.29"
 portable-pty = "0.9.0"
 clap = { version = "4.6.0", features = ["derive", "std"] }
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unreachable_pub = "warn"
+unused_qualifications = "warn"
+single_use_lifetimes = "warn"
+trivial_numeric_casts = "warn"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"
+rest_pat_in_fully_bound_structs = "warn"
+clone_on_ref_ptr = "warn"
+negative_feature_names = "warn"
+redundant_feature_names = "warn"
+wildcard_dependencies = "warn"

--- a/crates/pid-ctl-core/Cargo.toml
+++ b/crates/pid-ctl-core/Cargo.toml
@@ -14,8 +14,5 @@ categories.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
+[lints]
+workspace = true

--- a/crates/pid-ctl-core/tests/req/support.rs
+++ b/crates/pid-ctl-core/tests/req/support.rs
@@ -1,10 +1,15 @@
 use pid_ctl_core::{PidConfig, PidController, PidRuntimeState, StepInput, StepResult};
 
-pub fn controller(config: PidConfig) -> PidController {
+pub(crate) fn controller(config: PidConfig) -> PidController {
     PidController::new(config).expect("valid test config")
 }
 
-pub fn step(controller: &mut PidController, pv: f64, dt: f64, prev_applied_cv: f64) -> StepResult {
+pub(crate) fn step(
+    controller: &mut PidController,
+    pv: f64,
+    dt: f64,
+    prev_applied_cv: f64,
+) -> StepResult {
     controller.step(StepInput {
         pv,
         dt,
@@ -12,13 +17,13 @@ pub fn step(controller: &mut PidController, pv: f64, dt: f64, prev_applied_cv: f
     })
 }
 
-pub fn restored_controller(config: PidConfig, state: &PidRuntimeState) -> PidController {
+pub(crate) fn restored_controller(config: PidConfig, state: &PidRuntimeState) -> PidController {
     let mut controller = controller(config);
     controller.restore_state(state);
     controller
 }
 
-pub fn assert_close(actual: f64, expected: f64) {
+pub(crate) fn assert_close(actual: f64, expected: f64) {
     let delta = (actual - expected).abs();
     assert!(
         delta < 1e-9,

--- a/crates/pid-ctl-sim/Cargo.toml
+++ b/crates/pid-ctl-sim/Cargo.toml
@@ -19,8 +19,5 @@ assert_cmd.workspace = true
 predicates.workspace = true
 tempfile.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
+[lints]
+workspace = true

--- a/crates/pid-ctl-sim/src/state.rs
+++ b/crates/pid-ctl-sim/src/state.rs
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn sim_error_implements_std_error() {
         use std::error::Error;
-        let e = crate::SimError::Validation(String::from("test"));
+        let e = SimError::Validation(String::from("test"));
         assert!(e.source().is_none());
         assert_eq!(e.to_string(), "test");
     }

--- a/crates/pid-ctl/Cargo.toml
+++ b/crates/pid-ctl/Cargo.toml
@@ -32,8 +32,5 @@ predicates.workspace = true
 pretty_assertions.workspace = true
 portable-pty.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
+[lints]
+workspace = true

--- a/crates/pid-ctl/src/adapters/mod.rs
+++ b/crates/pid-ctl/src/adapters/mod.rs
@@ -168,7 +168,7 @@ impl FilePvSource {
 
 impl PvSource for FilePvSource {
     fn read_pv(&mut self) -> io::Result<f64> {
-        let content = std::fs::read_to_string(&self.path)?;
+        let content = fs::read_to_string(&self.path)?;
         content.trim().parse::<f64>().map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/crates/pid-ctl/src/json_events.rs
+++ b/crates/pid-ctl/src/json_events.rs
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn socket_ready_event_fields() {
         let mut logger = Logger::from_file(tempfile::tempfile().unwrap());
-        emit_socket_ready(&mut logger, std::path::PathBuf::from("/tmp/ctl.sock"));
+        emit_socket_ready(&mut logger, PathBuf::from("/tmp/ctl.sock"));
         let mut f = logger.into_file().unwrap();
         let mut s = String::new();
         f.seek(SeekFrom::Start(0)).unwrap();

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -511,7 +511,7 @@ fn sleep_with_socket(
     }
 }
 
-fn run_status(state_path: &std::path::Path) -> Result<(), CliError> {
+fn run_status(state_path: &Path) -> Result<(), CliError> {
     let store = StateStore::new(state_path);
     let snapshot = store
         .load()
@@ -532,7 +532,7 @@ fn run_status(state_path: &std::path::Path) -> Result<(), CliError> {
     Ok(())
 }
 
-fn run_purge(state_path: &std::path::Path) -> Result<(), CliError> {
+fn run_purge(state_path: &Path) -> Result<(), CliError> {
     let store = StateStore::new(state_path);
     let _lock = store
         .acquire_lock()
@@ -575,7 +575,7 @@ fn run_purge(state_path: &std::path::Path) -> Result<(), CliError> {
     Ok(())
 }
 
-fn run_init(state_path: &std::path::Path) -> Result<(), CliError> {
+fn run_init(state_path: &Path) -> Result<(), CliError> {
     let store = StateStore::new(state_path);
     let _lock = store
         .acquire_lock()

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -59,7 +59,7 @@ use std::time::{Duration, Instant};
 // The event loop integrates input, PID ticking, socket servicing, and throttled redraws in one
 // place — splitting it further would require passing state through many helper boundaries.
 #[allow(clippy::too_many_lines)]
-pub fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
+pub(crate) fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliError> {
     let mut session = ControllerSession::new(args.session_config())
         .map_err(|e| CliError::config(e.to_string()))?;
     let cfg0 = session.config().clone();

--- a/crates/pid-ctl/src/tune/render.rs
+++ b/crates/pid-ctl/src/tune/render.rs
@@ -436,7 +436,7 @@ pub(in crate::tune) fn render_frame(
                     ctx.print(
                         x_max,
                         *y,
-                        ratatui::text::Span::styled(*sym, Style::default().fg(Color::DarkGray)),
+                        Span::styled(*sym, Style::default().fg(Color::DarkGray)),
                     );
                 }
             }),

--- a/crates/pid-ctl/src/tune/tests.rs
+++ b/crates/pid-ctl/src/tune/tests.rs
@@ -120,7 +120,7 @@ fn history_trend_falling() {
     let mut d = VecDeque::new();
     d.push_back(5.0);
     d.push_back(1.0);
-    assert_eq!(super::history_trend(&d), "▼");
+    assert_eq!(history_trend(&d), "▼");
 }
 
 #[test]
@@ -128,13 +128,13 @@ fn history_trend_stable() {
     let mut d = VecDeque::new();
     d.push_back(3.0);
     d.push_back(3.0);
-    assert_eq!(super::history_trend(&d), "→");
+    assert_eq!(history_trend(&d), "→");
 }
 
 #[test]
 fn history_trend_empty_is_stable() {
     let d: VecDeque<f64> = VecDeque::new();
-    assert_eq!(super::history_trend(&d), "→");
+    assert_eq!(history_trend(&d), "→");
 }
 
 #[test]

--- a/crates/pid-ctl/tests/req/helpers.rs
+++ b/crates/pid-ctl/tests/req/helpers.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 /// Asserts `value["ts"]` is present and matches ISO 8601 UTC with second precision (`YYYY-MM-DDTHH:MM:SSZ`),
 /// consistent with [`pid_ctl::app::now_iso8601`].
-pub fn assert_json_ts_iso8601_utc(value: &Value) {
+pub(crate) fn assert_json_ts_iso8601_utc(value: &Value) {
     let ts = value["ts"].as_str().expect("ts field should be a string");
     assert_eq!(
         ts.len(),
@@ -12,9 +12,10 @@ pub fn assert_json_ts_iso8601_utc(value: &Value) {
         "ts should be 20 chars (YYYY-MM-DDTHH:MM:SSZ), got {ts:?}"
     );
     assert!(ts.ends_with('Z'), "ts should use UTC suffix Z, got {ts:?}");
-    assert_eq!(&ts[4..5], "-");
-    assert_eq!(&ts[7..8], "-");
-    assert_eq!(&ts[10..11], "T");
-    assert_eq!(&ts[13..14], ":");
-    assert_eq!(&ts[16..17], ":");
+    let bytes = ts.as_bytes();
+    assert_eq!(bytes[4], b'-');
+    assert_eq!(bytes[7], b'-');
+    assert_eq!(bytes[10], b'T');
+    assert_eq!(bytes[13], b':');
+    assert_eq!(bytes[16], b':');
 }

--- a/crates/pid-ctl/tests/req/req_once_pipe.rs
+++ b/crates/pid-ctl/tests/req/req_once_pipe.rs
@@ -218,7 +218,7 @@ fn pipe_with_scale() {
 /// `pipe --log <path>` appends one NDJSON iteration record per PV line to the log file.
 #[test]
 fn pipe_log_writes_iteration_records() {
-    let dir = tempfile::tempdir().expect("temporary directory");
+    let dir = tempdir().expect("temporary directory");
     let log_path = dir.path().join("pipe.ndjson");
 
     let mut cmd = Command::cargo_bin("pid-ctl").expect("pid-ctl binary");

--- a/crates/pid-ctl/tests/req/req_reliability.rs
+++ b/crates/pid-ctl/tests/req/req_reliability.rs
@@ -20,7 +20,7 @@ fn pv_read_failure_invokes_safe_cv_or_hold_last_per_plan() {
     cmd.arg(&cv_safe);
     cmd.args(["--safe-cv", "12.34"]);
 
-    cmd.timeout(Duration::from_millis(500));
+    cmd.timeout(Duration::from_secs(3));
     let _ = cmd.output();
 
     let content = std::fs::read_to_string(&cv_safe).expect("read cv file after PV failure");
@@ -40,7 +40,7 @@ fn pv_read_failure_invokes_safe_cv_or_hold_last_per_plan() {
     cmd.args(["--cv-file"]);
     cmd.arg(&cv_hold);
 
-    cmd.timeout(Duration::from_millis(500));
+    cmd.timeout(Duration::from_secs(3));
     let _ = cmd.output();
 
     let held = std::fs::read_to_string(&cv_hold).expect("read cv file");

--- a/crates/pid-ctl/tests/req/req_state_write_interval.rs
+++ b/crates/pid-ctl/tests/req/req_state_write_interval.rs
@@ -106,7 +106,7 @@ fn state_fail_after_escalates_to_prominent_warning() {
     use std::process;
 
     // root bypasses chmod permission checks; the test can't simulate write failures.
-    let uid = std::process::Command::new("id")
+    let uid = process::Command::new("id")
         .arg("-u")
         .output()
         .map(|o| o.stdout)


### PR DESCRIPTION
Consolidate per-crate [lints] into [workspace.lints] and layer a small,
empirically clean set of rustc and clippy lints on top of the existing
forbid(unsafe_code) + clippy::pedantic baseline.

New rustc lints (warn): unreachable_pub, unused_qualifications,
single_use_lifetimes, trivial_numeric_casts.

New clippy lints (warn): dbg_macro, todo, unimplemented,
rest_pat_in_fully_bound_structs, clone_on_ref_ptr,
negative_feature_names, redundant_feature_names, wildcard_dependencies.

Adopt only lints that were either already clean or had a handful of
mechanical hits. Fixes applied:
- unreachable_pub: narrow test helpers and tune::run to pub(crate)
- unused_qualifications: drop redundant std::/crate::/super:: prefixes

Higher-churn lints (missing_docs, allow_attributes{,_without_reason},
let_underscore_drop, missing_debug_implementations, clippy::panic) are
intentionally left for focused follow-ups — each would have required
dozens to hundreds of non-mechanical edits that don't belong in a
lint-config change.