### PR TITLE
refactor: excise cut corners flagged by tech-debt review

### DIFF
--- a/crates/pid-ctl/src/app/adapters_build.rs
+++ b/crates/pid-ctl/src/app/adapters_build.rs
@@ -1,19 +1,32 @@
 //! PV source and CV sink configuration enums plus their builder functions.
 //!
-//! `PvSourceConfig` and `CvSinkConfig` live here so the library can own
-//! `build_pv_source` / `build_cv_sink` without depending on the binary's CLI types.
+//! `OncePvSource`, `LoopPvSource`, and `CvSinkConfig` live here so the library can own
+//! `build_loop_pv_source` / `build_cv_sink` without depending on the binary's CLI types.
 //! The binary's `cli/types.rs` re-exports them.
+//!
+//! PV sources are split per subcommand so the type system encodes which inputs are valid
+//! for each mode: `once` accepts a literal, a file, or a command; `loop` accepts a file,
+//! a command, or stdin. This removes the runtime `unreachable!()` panics that would fire
+//! if CLI validation ever missed a case.
 
 use crate::adapters::{
-    CmdCvSink, CmdPvSource, CvSink, FileCvSink, FilePvSource, PvSource, StdinPvSource, StdoutCvSink,
+    CmdCvSink, CmdPvSource, CvSink, DryRunCvSink, FileCvSink, FilePvSource, PvSource,
+    StdinPvSource, StdoutCvSink,
 };
 use std::path::PathBuf;
 use std::time::Duration;
 
-/// Which PV source was specified on the CLI.
+/// PV source accepted by the `once` subcommand (no stdin — `once` reads PV once).
 #[derive(Clone, Debug, PartialEq)]
-pub enum PvSourceConfig {
+pub enum OncePvSource {
     Literal(f64),
+    File(PathBuf),
+    Cmd(String),
+}
+
+/// PV source accepted by the `loop` subcommand (no literal — `loop` reads PV every tick).
+#[derive(Clone, Debug, PartialEq)]
+pub enum LoopPvSource {
     File(PathBuf),
     Cmd(String),
     /// `loop --pv-stdin`: one line per tick, with a per-tick timeout.
@@ -33,17 +46,39 @@ pub enum CvSinkConfig {
     },
 }
 
+/// What to do with computed CV values.
+///
+/// Either discard (dry-run) or forward to a configured sink. Parse-time
+/// validation rejects the invalid fourth state (no sink, no dry-run), so
+/// matching is total and the runtime cannot hit an `unwrap`/`expect`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CvMode {
+    DryRun,
+    Sink(CvSinkConfig),
+}
+
 #[must_use]
-pub fn build_pv_source(
-    source: &PvSourceConfig,
+pub fn build_loop_pv_source(
+    source: &LoopPvSource,
     cmd_timeout: Duration,
     pv_stdin_timeout: Duration,
 ) -> Box<dyn PvSource> {
     match source {
-        PvSourceConfig::Literal(_) => unreachable!("loop rejects literal PV"),
-        PvSourceConfig::File(path) => Box::new(FilePvSource::new(path.clone())),
-        PvSourceConfig::Cmd(cmd) => Box::new(CmdPvSource::new(cmd.clone(), cmd_timeout)),
-        PvSourceConfig::Stdin => Box::new(StdinPvSource::new(pv_stdin_timeout)),
+        LoopPvSource::File(path) => Box::new(FilePvSource::new(path.clone())),
+        LoopPvSource::Cmd(cmd) => Box::new(CmdPvSource::new(cmd.clone(), cmd_timeout)),
+        LoopPvSource::Stdin => Box::new(StdinPvSource::new(pv_stdin_timeout)),
+    }
+}
+
+#[must_use]
+pub fn build_cv_mode_sink(
+    cv_mode: &CvMode,
+    precision: usize,
+    default_cmd_timeout: Duration,
+) -> Box<dyn CvSink> {
+    match cv_mode {
+        CvMode::DryRun => Box::new(DryRunCvSink),
+        CvMode::Sink(cfg) => build_cv_sink(cfg, precision, default_cmd_timeout),
     }
 }
 

--- a/crates/pid-ctl/src/app/defaults.rs
+++ b/crates/pid-ctl/src/app/defaults.rs
@@ -1,0 +1,41 @@
+//! Named defaults for loop timing parameters.
+//!
+//! These values were previously duplicated as bare literals across `parse.rs`,
+//! `loop_runtime.rs`, `main.rs`, and `socket.rs`. Consolidating them here makes
+//! the policy auditable in one place and eliminates drift between the parse-time
+//! default and the runtime re-derivation inside `apply_runtime_interval`.
+//!
+//! Corresponds to the defaults described in `pid-ctl_plan.md` (Reliability &
+//! Operational Safety, §dt handling and §state flush coalescing).
+
+use std::time::Duration;
+
+/// Minimum accepted measured `dt` in seconds. Samples below this are skipped
+/// (or clamped under `--dt-clamp`) to avoid derivative blow-up.
+pub const MIN_DT_DEFAULT: f64 = 0.01;
+
+/// Maximum accepted measured `dt` in seconds. Samples above this are skipped
+/// (or clamped under `--dt-clamp`) to avoid integrator runaway.
+pub const MAX_DT_DEFAULT: f64 = 60.0;
+
+/// Default `max_dt` is this multiple of the configured `--interval`, capped at
+/// `MAX_DT_DEFAULT` and floored at `MIN_DT_DEFAULT`.
+pub const MAX_DT_INTERVAL_MULTIPLIER: f64 = 3.0;
+
+/// Minimum state-flush interval. Always honoured even when `--interval` is
+/// shorter, so disk I/O does not saturate on sub-100 ms tick rates.
+pub const MIN_STATE_FLUSH: Duration = Duration::from_millis(100);
+
+/// Upper bound for the default `--cmd-timeout` (it is `min(interval, this)`).
+pub const DEFAULT_CMD_TIMEOUT_CAP: Duration = Duration::from_secs(30);
+
+/// Per-request I/O timeout on the operator socket. Short enough to not stall
+/// the tick, long enough to absorb typical fork/exec latency.
+pub const SOCKET_IO_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Chunk size used when the tick sleep is serviced alongside socket polls.
+pub const SOCKET_SLEEP_CHUNK: Duration = Duration::from_millis(50);
+
+/// Default tracking-time upper bound for anti-windup, expressed as a multiple
+/// of the loop interval (so faster loops tolerate shorter `Tt`).
+pub const ANTI_WINDUP_TT_INTERVAL_MULTIPLIER: f64 = 100.0;

--- a/crates/pid-ctl/src/app/loop_runtime.rs
+++ b/crates/pid-ctl/src/app/loop_runtime.rs
@@ -2,6 +2,9 @@
 //! reporting, and the [`LoopControls`] abstraction used by both the main loop and socket dispatch.
 
 use crate::adapters::CvSink;
+use crate::app::defaults::{
+    MAX_DT_DEFAULT, MAX_DT_INTERVAL_MULTIPLIER, MIN_DT_DEFAULT, MIN_STATE_FLUSH,
+};
 use crate::app::logger::Logger;
 use crate::app::{ControllerSession, StateStoreError};
 use crate::json_events;
@@ -42,10 +45,10 @@ pub fn apply_runtime_interval(
 ) {
     controls.set_interval(new_interval);
     let s = new_interval.as_secs_f64();
-    controls.maybe_set_max_dt((s * 3.0_f64).clamp(0.01, 60.0));
+    controls
+        .maybe_set_max_dt((s * MAX_DT_INTERVAL_MULTIPLIER).clamp(MIN_DT_DEFAULT, MAX_DT_DEFAULT));
     controls.maybe_set_pv_stdin_timeout(new_interval);
-    let min_flush = Duration::from_millis(100);
-    controls.maybe_set_state_write_interval(Some(new_interval.max(min_flush)));
+    controls.maybe_set_state_write_interval(Some(new_interval.max(MIN_STATE_FLUSH)));
     session.set_flush_interval(controls.state_write_interval());
 }
 

--- a/crates/pid-ctl/src/app/mod.rs
+++ b/crates/pid-ctl/src/app/mod.rs
@@ -1,6 +1,7 @@
 //! Controller session scaffolding and persistence primitives for the application layer.
 
 pub mod adapters_build;
+pub mod defaults;
 pub mod logger;
 pub mod loop_runtime;
 pub mod snapshot_persister;
@@ -126,8 +127,7 @@ impl ControllerSession {
 
     /// Current iteration count from the snapshot.
     #[must_use]
-    #[allow(clippy::iter_not_returning_iterator)]
-    pub const fn iter(&self) -> u64 {
+    pub const fn iteration(&self) -> u64 {
         self.snapshot.iter
     }
 

--- a/crates/pid-ctl/src/app/socket_dispatch.rs
+++ b/crates/pid-ctl/src/app/socket_dispatch.rs
@@ -33,7 +33,7 @@ pub fn handle_socket_request(
             (
                 Response::Status {
                     ok: true,
-                    iter: session.iter(),
+                    iter: session.iteration(),
                     pv: session.last_pv().unwrap_or(0.0),
                     sp: cfg.setpoint,
                     err: session.last_error().unwrap_or(0.0),
@@ -52,7 +52,7 @@ pub fn handle_socket_request(
         Request::Reset => {
             let i_acc_before = session.i_acc();
             session.reset_integral();
-            json_events::emit_integral_reset(logger, i_acc_before, session.iter(), "socket");
+            json_events::emit_integral_reset(logger, i_acc_before, session.iteration(), "socket");
             (
                 Response::Reset {
                     ok: true,
@@ -143,7 +143,7 @@ fn apply_gain_param(
         session.config().ki,
         session.config().kd,
         session.config().setpoint,
-        session.iter(),
+        session.iteration(),
         "socket",
     );
     old
@@ -196,7 +196,7 @@ fn handle_socket_set(
                 session.config().ki,
                 session.config().kd,
                 value,
-                session.iter(),
+                session.iteration(),
                 "socket",
             );
             (

--- a/crates/pid-ctl/src/cli/parse.rs
+++ b/crates/pid-ctl/src/cli/parse.rs
@@ -1,12 +1,16 @@
 use super::raw::{LoopRawArgs, OnceRawArgs, PipeRawArgs, StatusRawArgs};
 use super::types::{
-    CvSinkConfig, LoopArgs, LoopRuntimeConfig, OnceArgs, OutputFormat, PidFlags, PipeArgs,
-    PvSourceConfig, SetArgs, StatusFlags,
+    CvMode, CvSinkConfig, LoopArgs, LoopPvSource, LoopRuntimeConfig, OnceArgs, OncePvSource,
+    OutputFormat, PidFlags, PipeArgs, SetArgs, StatusFlags,
 };
 use super::user_set::UserSet;
 use crate::CliError;
 use pid_ctl::adapters::{CmdPvSource, FilePvSource, PvSource};
 use pid_ctl::app::StateStore;
+use pid_ctl::app::defaults::{
+    ANTI_WINDUP_TT_INTERVAL_MULTIPLIER, DEFAULT_CMD_TIMEOUT_CAP, MAX_DT_DEFAULT,
+    MAX_DT_INTERVAL_MULTIPLIER, MIN_DT_DEFAULT, MIN_STATE_FLUSH,
+};
 use pid_ctl_core::{AntiWindupStrategy, PidConfig};
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
@@ -89,6 +93,11 @@ pub(crate) fn parse_once(raw: &OnceRawArgs) -> Result<OnceArgs, CliError> {
         apply_verify_cv(sink, raw.cv.verify_cv);
     }
 
+    let cv_mode = match (raw.dry_run, cv_sink) {
+        (true, _) | (false, None) => CvMode::DryRun,
+        (false, Some(cfg)) => CvMode::Sink(cfg),
+    };
+
     let (dt, dt_explicit) = if let Some(v) = raw.common.dt {
         (v, true)
     } else {
@@ -101,10 +110,10 @@ pub(crate) fn parse_once(raw: &OnceRawArgs) -> Result<OnceArgs, CliError> {
         pv_cmd_timeout,
         dt,
         dt_explicit,
-        min_dt: raw.common.min_dt.unwrap_or(0.01),
-        max_dt: raw.common.max_dt.unwrap_or(60.0),
+        min_dt: raw.common.min_dt.unwrap_or(MIN_DT_DEFAULT),
+        max_dt: raw.common.max_dt.unwrap_or(MAX_DT_DEFAULT),
         output_format,
-        cv_sink,
+        cv_mode,
         pid_config,
         state_path: raw.common.state.clone(),
         name: raw.common.name.clone(),
@@ -112,7 +121,6 @@ pub(crate) fn parse_once(raw: &OnceRawArgs) -> Result<OnceArgs, CliError> {
         scale: raw.common.scale.unwrap_or(1.0),
         cv_precision: raw.common.cv_precision.unwrap_or(2) as usize,
         log_path: raw.common.log.clone(),
-        dry_run: raw.dry_run,
     })
 }
 
@@ -208,7 +216,7 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
                 "--tune and --quiet are incompatible — tune requires a TTY",
             ));
         }
-        if matches!(pv_source, PvSourceConfig::Stdin) {
+        if matches!(pv_source, LoopPvSource::Stdin) {
             return Err(CliError::config(
                 "--tune cannot be used with --pv-stdin — stdin is used for the tuning dashboard",
             ));
@@ -250,25 +258,22 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
     let pid_flags = raw.pid.to_pid_flags()?;
     let mut pid_config = resolve_pid_config(&pid_flags, raw.common.state.as_deref())?;
 
-    // Default max_dt is 3×interval or 60.0 if interval is very large.
     let interval_secs = interval.as_secs_f64();
 
-    // Set tt_upper_bound from interval.
     if raw.pid.anti_windup_tt.is_none() {
-        pid_config.tt_upper_bound = Some(100.0 * interval_secs);
+        pid_config.tt_upper_bound = Some(ANTI_WINDUP_TT_INTERVAL_MULTIPLIER * interval_secs);
     }
-    let max_dt_default = (interval_secs * 3.0).min(60.0);
-    // Ensure max_dt_default is never below min_dt default (0.01).
-    let max_dt_default = max_dt_default.max(0.01);
+    let max_dt_default =
+        (interval_secs * MAX_DT_INTERVAL_MULTIPLIER).clamp(MIN_DT_DEFAULT, MAX_DT_DEFAULT);
 
     let pv_stdin_timeout = raw
         .pv
         .pv_stdin_timeout
         .map_or_else(|| UserSet::Default(interval), UserSet::Explicit);
 
-    // Default cmd-timeout: min(interval, 30s).
+    // Default cmd-timeout: min(interval, DEFAULT_CMD_TIMEOUT_CAP).
     let effective_cmd_timeout = raw.common.cmd_timeout.map_or_else(
-        || interval.min(Duration::from_secs(30)),
+        || interval.min(DEFAULT_CMD_TIMEOUT_CAP),
         Duration::from_secs_f64,
     );
     let pv_cmd_timeout = raw
@@ -276,9 +281,8 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
         .pv_cmd_timeout
         .map_or(effective_cmd_timeout, Duration::from_secs_f64);
 
-    // Default state_write_interval for loop: max(tick_interval, 100ms).
-    let min_flush = Duration::from_millis(100);
-    let default_state_write_interval = interval.max(min_flush);
+    // Default state_write_interval for loop: max(tick_interval, MIN_STATE_FLUSH).
+    let default_state_write_interval = interval.max(MIN_STATE_FLUSH);
     let state_write_interval = raw.common.state_write_interval.map_or_else(
         || UserSet::Default(Some(default_state_write_interval)),
         |t| UserSet::Explicit(Some(t)),
@@ -345,6 +349,7 @@ pub(crate) fn parse_loop(raw: &LoopRawArgs) -> Result<LoopArgs, CliError> {
         socket_path,
         #[cfg(unix)]
         socket_mode,
+        max_iterations: raw.max_iterations,
     })
 }
 
@@ -485,12 +490,11 @@ pub(crate) const fn apply_verify_cv(cv_sink: &mut CvSinkConfig, verify: bool) {
     }
 }
 
-pub(crate) fn resolve_pv(source: &PvSourceConfig, cmd_timeout: Duration) -> io::Result<f64> {
+pub(crate) fn resolve_pv(source: &OncePvSource, cmd_timeout: Duration) -> io::Result<f64> {
     match source {
-        PvSourceConfig::Literal(v) => Ok(*v),
-        PvSourceConfig::File(path) => FilePvSource::new(path.clone()).read_pv(),
-        PvSourceConfig::Cmd(cmd) => CmdPvSource::new(cmd.clone(), cmd_timeout).read_pv(),
-        PvSourceConfig::Stdin => unreachable!("--pv-stdin is only valid for loop, not once"),
+        OncePvSource::Literal(v) => Ok(*v),
+        OncePvSource::File(path) => FilePvSource::new(path.clone()).read_pv(),
+        OncePvSource::Cmd(cmd) => CmdPvSource::new(cmd.clone(), cmd_timeout).read_pv(),
     }
 }
 

--- a/crates/pid-ctl/src/cli/raw.rs
+++ b/crates/pid-ctl/src/cli/raw.rs
@@ -1,5 +1,5 @@
 use super::parse::parse_duration_flag;
-use super::types::{CvSinkConfig, PidFlags, PvSourceConfig};
+use super::types::{CvSinkConfig, LoopPvSource, OncePvSource, PidFlags};
 use crate::CliError;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use pid_ctl_core::AntiWindupStrategy;
@@ -349,7 +349,7 @@ pub(super) struct OncePvRawArgs {
 }
 
 impl OncePvRawArgs {
-    pub(super) fn to_pv_source_config(&self) -> Result<Option<PvSourceConfig>, CliError> {
+    pub(super) fn to_pv_source_config(&self) -> Result<Option<OncePvSource>, CliError> {
         // Reject flags invalid for once.
         if self.pv_stdin {
             return Err(CliError::config(
@@ -374,14 +374,14 @@ impl OncePvRawArgs {
         }
 
         if let Some(&v) = self.pv.first() {
-            Ok(Some(PvSourceConfig::Literal(v)))
+            Ok(Some(OncePvSource::Literal(v)))
         } else if let Some(ref path) = self.pv_file {
-            Ok(Some(PvSourceConfig::File(path.clone())))
+            Ok(Some(OncePvSource::File(path.clone())))
         } else {
             Ok(self
                 .pv_cmd
                 .as_ref()
-                .map(|cmd| PvSourceConfig::Cmd(cmd.clone())))
+                .map(|cmd| OncePvSource::Cmd(cmd.clone())))
         }
     }
 }
@@ -414,7 +414,7 @@ pub(super) struct LoopPvRawArgs {
 }
 
 impl LoopPvRawArgs {
-    pub(super) fn to_pv_source_config(&self) -> Result<Option<PvSourceConfig>, CliError> {
+    pub(super) fn to_pv_source_config(&self) -> Result<Option<LoopPvSource>, CliError> {
         // loop does not accept --pv <literal>
         if self.pv.is_some() {
             return Err(CliError::config(
@@ -438,11 +438,11 @@ impl LoopPvRawArgs {
         }
 
         if let Some(ref path) = self.pv_file {
-            Ok(Some(PvSourceConfig::File(path.clone())))
+            Ok(Some(LoopPvSource::File(path.clone())))
         } else if let Some(ref cmd) = self.pv_cmd {
-            Ok(Some(PvSourceConfig::Cmd(cmd.clone())))
+            Ok(Some(LoopPvSource::Cmd(cmd.clone())))
         } else if self.pv_stdin {
-            Ok(Some(PvSourceConfig::Stdin))
+            Ok(Some(LoopPvSource::Stdin))
         } else {
             Ok(None)
         }
@@ -625,6 +625,10 @@ pub(crate) struct LoopRawArgs {
     #[cfg(unix)]
     #[arg(long, value_parser = parse_octal_mode)]
     pub(super) socket_mode: Option<u32>,
+
+    /// Exit cleanly after this many successful PID ticks (test hook; hidden).
+    #[arg(long, hide = true)]
+    pub(super) max_iterations: Option<u64>,
 }
 
 /// `pipe` — read PV from stdin, emit CV to stdout.

--- a/crates/pid-ctl/src/cli/types.rs
+++ b/crates/pid-ctl/src/cli/types.rs
@@ -5,7 +5,7 @@ use pid_ctl_core::PidConfig;
 use std::path::PathBuf;
 use std::time::Duration;
 
-pub(crate) use pid_ctl::app::adapters_build::{CvSinkConfig, PvSourceConfig};
+pub(crate) use pid_ctl::app::adapters_build::{CvMode, CvSinkConfig, LoopPvSource, OncePvSource};
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) enum OutputFormat {
@@ -33,7 +33,7 @@ pub(crate) struct PidFlags {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct OnceArgs {
-    pub(crate) pv_source: PvSourceConfig,
+    pub(crate) pv_source: OncePvSource,
     pub(crate) cmd_timeout: Duration,
     pub(crate) pv_cmd_timeout: Duration,
     pub(crate) dt: f64,
@@ -41,7 +41,7 @@ pub(crate) struct OnceArgs {
     pub(crate) min_dt: f64,
     pub(crate) max_dt: f64,
     pub(crate) output_format: OutputFormat,
-    pub(crate) cv_sink: Option<CvSinkConfig>,
+    pub(crate) cv_mode: CvMode,
     pub(crate) pid_config: PidConfig,
     pub(crate) state_path: Option<PathBuf>,
     pub(crate) name: Option<String>,
@@ -49,7 +49,6 @@ pub(crate) struct OnceArgs {
     pub(crate) scale: f64,
     pub(crate) cv_precision: usize,
     pub(crate) log_path: Option<PathBuf>,
-    pub(crate) dry_run: bool,
 }
 
 impl OnceArgs {
@@ -144,7 +143,7 @@ impl LoopControls for LoopRuntimeConfig {
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct LoopArgs {
     pub(crate) runtime: LoopRuntimeConfig,
-    pub(crate) pv_source: PvSourceConfig,
+    pub(crate) pv_source: LoopPvSource,
     pub(crate) cv_sink: Option<CvSinkConfig>,
     pub(crate) pid_config: PidConfig,
     pub(crate) state_path: Option<PathBuf>,
@@ -177,6 +176,8 @@ pub(crate) struct LoopArgs {
     pub(crate) socket_path: Option<PathBuf>,
     #[cfg(unix)]
     pub(crate) socket_mode: u32,
+    /// Exit after this many completed PID ticks (test hook; `None` = unbounded).
+    pub(crate) max_iterations: Option<u64>,
 }
 
 impl LoopArgs {
@@ -188,6 +189,18 @@ impl LoopArgs {
             reset_accumulator: self.reset_accumulator,
             flush_interval: self.runtime.state_write_interval(),
             state_fail_after: self.state_fail_after,
+        }
+    }
+
+    /// Resolves the CV mode for non-tune execution (`run_loop`).
+    ///
+    /// Parse validation guarantees that `cv_sink.is_none()` implies `dry_run`, so when
+    /// dry-run is active the hardware sink (if any) is ignored. `tune` mode does not use
+    /// this helper — it needs the hardware sink and a mutable dry-run flag independently.
+    pub(crate) fn cv_mode(&self) -> CvMode {
+        match (self.dry_run, self.cv_sink.clone()) {
+            (true, _) | (false, None) => CvMode::DryRun,
+            (false, Some(cfg)) => CvMode::Sink(cfg),
         }
     }
 }

--- a/crates/pid-ctl/src/lib.rs
+++ b/crates/pid-ctl/src/lib.rs
@@ -2,6 +2,14 @@
 //!
 //! Implementation is intentionally not started here — behavior is driven by requirement tests and
 //! `pid-ctl_plan.md` (Reliability & Operational Safety, Full CLI Reference, State File Schema).
+//!
+//! # No stable API contract
+//!
+//! Everything re-exported from this crate (`adapters`, `app`, `json_events`, `schedule`,
+//! `socket`) is the binary's shared plumbing — not a library surface for third-party
+//! consumers. Names, signatures, and module layout may change with any commit to serve
+//! the `pid-ctl` CLI's needs. If you need a stable library to embed PID control, depend
+//! on `pid-ctl-core` instead.
 
 #![forbid(unsafe_code)]
 

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -5,8 +5,8 @@ mod tune;
 pub(crate) use cli::*;
 
 use clap::Parser;
-use pid_ctl::adapters::{CvSink, DryRunCvSink, StdoutCvSink};
-use pid_ctl::app::adapters_build::{build_cv_sink, build_pv_source};
+use pid_ctl::adapters::{CvSink, StdoutCvSink};
+use pid_ctl::app::adapters_build::{build_cv_mode_sink, build_loop_pv_source};
 use pid_ctl::app::logger::Logger;
 use pid_ctl::app::loop_runtime::{
     LoopControls, MeasuredDt, apply_measured_dt, emit_state_write_failure, flush_state_at_shutdown,
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 #[cfg(unix)]
 use pid_ctl::app::socket_dispatch::{SocketSideEffect, handle_socket_request};
@@ -123,17 +123,8 @@ fn open_log(path: Option<&Path>) -> Result<Logger, CliError> {
 fn run_once(args: &OnceArgs) -> Result<(), CliError> {
     let mut session = ControllerSession::new(args.session_config())
         .map_err(|error| CliError::config(error.to_string()))?;
-    let mut sink: Box<dyn CvSink> = if args.dry_run {
-        Box::new(DryRunCvSink)
-    } else {
-        build_cv_sink(
-            args.cv_sink
-                .as_ref()
-                .expect("cv_sink required when not dry_run"),
-            args.cv_precision,
-            args.cmd_timeout,
-        )
-    };
+    let mut sink: Box<dyn CvSink> =
+        build_cv_mode_sink(&args.cv_mode, args.cv_precision, args.cmd_timeout);
     let mut logger = open_log(args.log_path.as_deref())?;
 
     let dt = resolve_once_dt(&session, args, &mut logger);
@@ -225,53 +216,23 @@ fn run_pipe(args: &PipeArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-#[allow(clippy::too_many_lines)]
 fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
     let mut session = ControllerSession::new(args.session_config())
         .map_err(|error| CliError::config(error.to_string()))?;
-    let mut pv_source = build_pv_source(
+    let mut pv_source = build_loop_pv_source(
         &args.pv_source,
         args.pv_cmd_timeout,
         args.runtime.pv_stdin_timeout(),
     );
-    let mut cv_sink: Box<dyn CvSink> = if args.dry_run {
-        Box::new(DryRunCvSink)
-    } else {
-        build_cv_sink(
-            args.cv_sink
-                .as_ref()
-                .expect("cv_sink required when not dry_run"),
-            args.cv_precision,
-            args.cmd_timeout,
-        )
-    };
+    let mut cv_sink: Box<dyn CvSink> =
+        build_cv_mode_sink(&args.cv_mode(), args.cv_precision, args.cmd_timeout);
 
     let mut logger = open_log(args.log_path.as_deref())?;
 
-    // Bind socket listener when --socket is set.
     #[cfg(unix)]
-    let socket_listener = if let Some(ref path) = args.socket_path {
-        let listener =
-            pid_ctl::socket::SocketListener::bind(path, args.socket_mode).map_err(|e| match e {
-                pid_ctl::socket::SocketError::AlreadyRunning => CliError::new(
-                    3,
-                    format!("socket {}: another instance is running", path.display()),
-                ),
-                other => CliError::new(1, format!("socket: {other}")),
-            })?;
-        json_events::emit_socket_ready(&mut logger, path.clone());
-        Some(listener)
-    } else {
-        None
-    };
+    let socket_listener = bind_socket_listener(args, &mut logger)?;
 
-    // Set up SIGTERM/SIGINT shutdown flag.
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_clone = Arc::clone(&shutdown);
-    ctrlc::set_handler(move || {
-        shutdown_clone.store(true, Ordering::Relaxed);
-    })
-    .expect("signal handler");
+    let shutdown = install_shutdown_handler();
 
     let mut next_deadline = Instant::now() + args.runtime.interval;
     let mut last_tick = Instant::now();
@@ -282,36 +243,24 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
     loop {
         // Check shutdown flag at top of each iteration.
         if shutdown.load(Ordering::Relaxed) {
-            write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-            flush_state_at_shutdown(&mut session, args.state_path.as_deref(), &mut logger);
+            finalize_shutdown(args, cv_sink.as_mut(), &mut session, &mut logger);
             break;
         }
 
-        // Sleep until next deadline, servicing socket if active.
-        let now = Instant::now();
-        if now < next_deadline {
+        sleep_until_next_deadline(
+            next_deadline,
             #[cfg(unix)]
-            if let Some(ref listener) = socket_listener {
-                sleep_with_socket(
-                    next_deadline,
-                    listener,
-                    &mut session,
-                    &mut args.runtime,
-                    &mut hold,
-                    &shutdown,
-                    &mut logger,
-                );
-            } else {
-                std::thread::sleep(next_deadline - now);
-            }
-            #[cfg(not(unix))]
-            std::thread::sleep(next_deadline - now);
-        }
+            socket_listener.as_ref(),
+            &mut session,
+            &mut args.runtime,
+            &mut hold,
+            &shutdown,
+            &mut logger,
+        );
 
         // Check shutdown again after sleeping (signal may have arrived during sleep).
         if shutdown.load(Ordering::Relaxed) {
-            write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-            flush_state_at_shutdown(&mut session, args.state_path.as_deref(), &mut logger);
+            finalize_shutdown(args, cv_sink.as_mut(), &mut session, &mut logger);
             break;
         }
 
@@ -328,64 +277,24 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         let raw_dt = now.duration_since(last_tick).as_secs_f64();
         last_tick = now;
 
-        // Interval slip (plan: Reliability §10 — tick longer than configured `--interval`).
         let interval_secs = args.runtime.interval.as_secs_f64();
-        if raw_dt > interval_secs {
-            if !args.quiet {
-                eprintln!(
-                    "interval slip: tick took {:.0}ms (interval: {:.0}ms)",
-                    raw_dt * 1000.0,
-                    interval_secs * 1000.0
-                );
-            }
-            let interval_ms = millis_round_u64(interval_secs * 1000.0);
-            let actual_ms = millis_round_u64(raw_dt * 1000.0);
-            json_events::emit_interval_slip(&mut logger, interval_ms, actual_ms);
-        }
+        log_interval_slip_if_needed(raw_dt, interval_secs, args.quiet, &mut logger);
 
-        let dt = match apply_measured_dt(
-            raw_dt,
-            *args.min_dt.value(),
-            args.runtime.max_dt(),
-            args.dt_clamp,
-            args.quiet,
-            &mut logger,
-        ) {
-            MeasuredDt::Skip => {
-                handle_dt_skip_state_write(
-                    session.on_dt_skipped(),
-                    &session,
-                    args.state_path.as_deref(),
-                    &mut logger,
-                    args.quiet,
-                );
-                continue;
-            }
-            MeasuredDt::Use(dt) => dt,
+        let Some(dt) = resolve_tick_dt(raw_dt, args, &mut session, &mut logger) else {
+            continue;
         };
 
-        // Read PV.
-        let raw_pv = match pv_source.read_pv() {
-            Ok(pv) => {
-                pv_fail_count = 0;
-                pv
-            }
-            Err(error) => {
-                pv_fail_count += 1;
-                eprintln!("PV read failed: {error}");
-                json_events::emit_pv_read_failure(&mut logger, error.to_string(), args.safe_cv);
-                write_safe_cv(args.safe_cv, cv_sink.as_mut(), &mut session);
-                if let Some(limit) = args.fail_after
-                    && pv_fail_count >= limit
-                {
-                    json_events::emit_pv_fail_after_reached(&mut logger, pv_fail_count, limit);
-                    return Err(CliError::new(
-                        2,
-                        format!("exiting after {pv_fail_count} consecutive PV read failures"),
-                    ));
-                }
-                continue;
-            }
+        let Some(raw_pv) = read_pv_with_escalation(
+            pv_source.as_mut(),
+            &mut pv_fail_count,
+            args.fail_after,
+            args.safe_cv,
+            cv_sink.as_mut(),
+            &mut session,
+            &mut logger,
+        )?
+        else {
+            continue;
         };
 
         let mut observer = LoopObserver {
@@ -409,9 +318,184 @@ fn run_loop(args: &mut LoopArgs) -> Result<(), CliError> {
         {
             return Err(CliError::new(2, msg));
         }
+
+        // Test hook: exit after N successful ticks so tests can synchronize on a
+        // deterministic signal instead of racing a wall-clock kill.
+        if let Some(limit) = args.max_iterations
+            && session.iteration() >= limit
+        {
+            finalize_shutdown(args, cv_sink.as_mut(), &mut session, &mut logger);
+            break;
+        }
     }
 
     Ok(())
+}
+
+/// Binds the optional Unix-socket listener for operator commands.
+#[cfg(unix)]
+fn bind_socket_listener(
+    args: &LoopArgs,
+    logger: &mut Logger,
+) -> Result<Option<pid_ctl::socket::SocketListener>, CliError> {
+    let Some(ref path) = args.socket_path else {
+        return Ok(None);
+    };
+    let listener =
+        pid_ctl::socket::SocketListener::bind(path, args.socket_mode).map_err(|e| match e {
+            pid_ctl::socket::SocketError::AlreadyRunning => CliError::new(
+                3,
+                format!("socket {}: another instance is running", path.display()),
+            ),
+            other => CliError::new(1, format!("socket: {other}")),
+        })?;
+    json_events::emit_socket_ready(logger, path.clone());
+    Ok(Some(listener))
+}
+
+/// Installs the SIGTERM/SIGINT handler and returns the shared shutdown flag.
+fn install_shutdown_handler() -> Arc<AtomicBool> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = Arc::clone(&shutdown);
+    ctrlc::set_handler(move || {
+        shutdown_clone.store(true, Ordering::Relaxed);
+    })
+    .expect("signal handler");
+    shutdown
+}
+
+/// Writes the safe CV and flushes state on shutdown.
+fn finalize_shutdown(
+    args: &LoopArgs,
+    cv_sink: &mut dyn CvSink,
+    session: &mut ControllerSession,
+    logger: &mut Logger,
+) {
+    write_safe_cv(args.safe_cv, cv_sink, session);
+    flush_state_at_shutdown(session, args.state_path.as_deref(), logger);
+}
+
+/// Resolves the tick's effective dt — applying clamp/skip semantics. Returns `None` when
+/// the tick should be skipped (and emits the associated state-write side effects).
+fn resolve_tick_dt(
+    raw_dt: f64,
+    args: &LoopArgs,
+    session: &mut ControllerSession,
+    logger: &mut Logger,
+) -> Option<f64> {
+    match apply_measured_dt(
+        raw_dt,
+        *args.min_dt.value(),
+        args.runtime.max_dt(),
+        args.dt_clamp,
+        args.quiet,
+        logger,
+    ) {
+        MeasuredDt::Skip => {
+            handle_dt_skip_state_write(
+                session.on_dt_skipped(),
+                session,
+                args.state_path.as_deref(),
+                logger,
+                args.quiet,
+            );
+            None
+        }
+        MeasuredDt::Use(dt) => Some(dt),
+    }
+}
+
+/// Sleeps until `next_deadline`, servicing the optional socket listener in small
+/// chunks so operator commands remain responsive while the loop waits for its tick.
+fn sleep_until_next_deadline(
+    next_deadline: Instant,
+    #[cfg(unix)] socket_listener: Option<&pid_ctl::socket::SocketListener>,
+    session: &mut ControllerSession,
+    runtime: &mut LoopRuntimeConfig,
+    hold: &mut bool,
+    shutdown: &AtomicBool,
+    logger: &mut Logger,
+) {
+    let now = Instant::now();
+    if now >= next_deadline {
+        return;
+    }
+
+    #[cfg(unix)]
+    if let Some(listener) = socket_listener {
+        sleep_with_socket(
+            next_deadline,
+            listener,
+            session,
+            runtime,
+            hold,
+            shutdown,
+            logger,
+        );
+        return;
+    }
+
+    // Fallback for non-unix or when no socket is bound — unused locals suppressed.
+    let _ = (session, runtime, hold, shutdown, logger);
+    std::thread::sleep(next_deadline - now);
+}
+
+/// Reads a PV sample, applying the safe-CV and escalation policy on failure.
+///
+/// Returns `Ok(Some(pv))` when a PV was read, `Ok(None)` when the caller should
+/// `continue` to the next tick, or `Err` when the failure limit was reached.
+fn read_pv_with_escalation(
+    pv_source: &mut dyn pid_ctl::adapters::PvSource,
+    pv_fail_count: &mut u32,
+    fail_after: Option<u32>,
+    safe_cv: Option<f64>,
+    cv_sink: &mut dyn CvSink,
+    session: &mut ControllerSession,
+    logger: &mut Logger,
+) -> Result<Option<f64>, CliError> {
+    match pv_source.read_pv() {
+        Ok(pv) => {
+            *pv_fail_count = 0;
+            Ok(Some(pv))
+        }
+        Err(error) => {
+            *pv_fail_count += 1;
+            eprintln!("PV read failed: {error}");
+            json_events::emit_pv_read_failure(logger, error.to_string(), safe_cv);
+            write_safe_cv(safe_cv, cv_sink, session);
+            if let Some(limit) = fail_after
+                && *pv_fail_count >= limit
+            {
+                json_events::emit_pv_fail_after_reached(logger, *pv_fail_count, limit);
+                return Err(CliError::new(
+                    2,
+                    format!(
+                        "exiting after {count} consecutive PV read failures",
+                        count = *pv_fail_count
+                    ),
+                ));
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// Emits the interval-slip event when a tick took longer than the configured interval
+/// (plan: Reliability §10).
+fn log_interval_slip_if_needed(raw_dt: f64, interval_secs: f64, quiet: bool, logger: &mut Logger) {
+    if raw_dt <= interval_secs {
+        return;
+    }
+    if !quiet {
+        eprintln!(
+            "interval slip: tick took {:.0}ms (interval: {:.0}ms)",
+            raw_dt * 1000.0,
+            interval_secs * 1000.0
+        );
+    }
+    let interval_ms = millis_round_u64(interval_secs * 1000.0);
+    let actual_ms = millis_round_u64(raw_dt * 1000.0);
+    json_events::emit_interval_slip(logger, interval_ms, actual_ms);
 }
 
 struct LoopObserver {
@@ -491,7 +575,7 @@ fn sleep_with_socket(
         if now >= until || shutdown.load(Ordering::Relaxed) {
             break;
         }
-        let chunk = (until - now).min(Duration::from_millis(50));
+        let chunk = (until - now).min(app::defaults::SOCKET_SLEEP_CHUNK);
         std::thread::sleep(chunk);
 
         for _ in 0..10 {

--- a/crates/pid-ctl/src/socket.rs
+++ b/crates/pid-ctl/src/socket.rs
@@ -4,6 +4,7 @@
 //! each tick to service operator commands (status, set, reset, hold, resume,
 //! save) without interrupting the control cadence.
 
+use crate::app::defaults::SOCKET_IO_TIMEOUT;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::fmt;
@@ -216,8 +217,8 @@ impl SocketListener {
             Ok(pair) => pair,
         };
 
-        stream.set_read_timeout(Some(Duration::from_millis(500)))?;
-        stream.set_write_timeout(Some(Duration::from_millis(500)))?;
+        stream.set_read_timeout(Some(SOCKET_IO_TIMEOUT))?;
+        stream.set_write_timeout(Some(SOCKET_IO_TIMEOUT))?;
 
         let mut buf = Vec::new();
         let bytes_read = (&stream)

--- a/crates/pid-ctl/src/tune/mod.rs
+++ b/crates/pid-ctl/src/tune/mod.rs
@@ -38,7 +38,7 @@ use export::{export_line_stderr, flush_shutdown};
 use input::{handle_command_key, handle_normal_key};
 use model::{TUNE_IDLE_DRAW_DEADLINE_NEAR, TUNE_IDLE_DRAW_MIN, TuneUiState};
 use pid_ctl::adapters::{CvSink, DryRunCvSink};
-use pid_ctl::app::adapters_build::{build_cv_sink, build_pv_source};
+use pid_ctl::app::adapters_build::{build_cv_sink, build_loop_pv_source};
 use pid_ctl::app::logger::Logger;
 use pid_ctl::app::loop_runtime::{
     LoopControls, MeasuredDt, apply_measured_dt, emit_state_write_failure,
@@ -69,7 +69,7 @@ pub(crate) fn run(mut args: LoopArgs, full_argv: &[String]) -> Result<(), CliErr
     ui.last_kd = cfg0.kd;
     ui.last_sp = cfg0.setpoint;
 
-    let mut pv_source = build_pv_source(
+    let mut pv_source = build_loop_pv_source(
         &args.pv_source,
         args.pv_cmd_timeout,
         args.runtime.pv_stdin_timeout(),

--- a/crates/pid-ctl/src/tune/tests.rs
+++ b/crates/pid-ctl/src/tune/tests.rs
@@ -490,7 +490,7 @@ fn test_loop_args(config: pid_ctl_core::PidConfig) -> super::LoopArgs {
             pv_stdin_timeout: crate::cli::user_set::UserSet::Default(Duration::from_secs(5)),
             state_write_interval: crate::cli::user_set::UserSet::Default(None),
         },
-        pv_source: pid_ctl::app::adapters_build::PvSourceConfig::Literal(0.0),
+        pv_source: pid_ctl::app::adapters_build::LoopPvSource::Cmd("echo 0".into()),
         cv_sink: None,
         pid_config: config,
         state_path: None,
@@ -523,6 +523,7 @@ fn test_loop_args(config: pid_ctl_core::PidConfig) -> super::LoopArgs {
         socket_path: None,
         #[cfg(unix)]
         socket_mode: 0o660,
+        max_iterations: None,
     }
 }
 

--- a/crates/pid-ctl/tests/req/req_loop.rs
+++ b/crates/pid-ctl/tests/req/req_loop.rs
@@ -10,14 +10,10 @@ use tempfile::tempdir;
 
 /// pid-ctl-cv1: loop runs continuously, advances iter, and writes state.
 ///
-/// Creates a temp PV file, runs loop with a very short interval, kills after
-/// ~300 ms, then checks the state file has iter >= 2.
-///
-/// Marked `#[ignore]` because the process-timing approach (kill after N ms) is
-/// inherently racy on slow/loaded CI machines and can produce iter == 1 or flap.
-/// Run manually with `cargo test -- --ignored loop_basic_iterations`.
+/// Uses `--max-iterations 3` (a hidden test hook) so the child exits on its own
+/// after three completed PID ticks. This replaces the earlier kill-after-N-ms
+/// approach, which was inherently racy on slow/loaded CI machines.
 #[test]
-#[ignore = "timing-sensitive: kill after 300 ms may land before 2 ticks on slow machines"]
 fn loop_basic_iterations() {
     let dir = tempdir().expect("temporary directory");
     let pv_path = dir.path().join("pv.txt");
@@ -37,17 +33,16 @@ fn loop_basic_iterations() {
         "50ms",
         "--cv-file",
         "/dev/null",
+        "--max-iterations",
+        "3",
         "--state",
     ]);
     cmd.arg(&state_path);
 
-    // Run for up to 500 ms then kill.
-    cmd.timeout(Duration::from_millis(500));
+    // Generous ceiling so the slowest CI runners still get a clean self-exit.
+    cmd.timeout(Duration::from_secs(10));
+    cmd.assert().success();
 
-    // Process will be killed (non-zero exit) — that's expected.
-    let _ = cmd.output();
-
-    // State file should exist and iter should be >= 2.
     assert!(
         state_path.exists(),
         "state file should exist after loop ran"
@@ -59,8 +54,8 @@ fn loop_basic_iterations() {
         .expect("snapshot present");
 
     assert!(
-        snapshot.iter >= 2,
-        "expected iter >= 2 after ~300 ms at 50 ms interval, got {}",
+        snapshot.iter >= 3,
+        "expected iter >= 3 after --max-iterations 3, got {}",
         snapshot.iter
     );
 }


### PR DESCRIPTION
Eliminates four runtime panics, un-ignores a timing-flaky test, and
replaces scattered magic numbers with named constants — the fixes laid
out in the "review the codebase for staged avalanche" plan.

Changes:
- Split PvSourceConfig into OncePvSource and LoopPvSource so
  build_loop_pv_source and resolve_pv become total matches; deletes two
  unreachable!() panics in adapters_build.rs and cli/parse.rs.
- Introduce CvMode (DryRun | Sink) so run_once / run_loop no longer
  need .expect("cv_sink required when not dry_run"). LoopArgs keeps
  cv_sink + dry_run for tune's runtime toggle and derives CvMode via
  LoopArgs::cv_mode() for the non-tune path.
- Rename ControllerSession::iter → iteration, removing the
  clippy::iter_not_returning_iterator suppression.
- Extract bind_socket_listener, install_shutdown_handler,
  finalize_shutdown, resolve_tick_dt, sleep_until_next_deadline,
  read_pv_with_escalation, and log_interval_slip_if_needed from
  run_loop; drops the clippy::too_many_lines allow.
- Add --max-iterations test hook (hidden flag) and rewrite
  loop_basic_iterations to exit on a deterministic signal instead of a
  kill-after-300ms race. Removes one of three #[ignore]d tests.
- Add crates/pid-ctl/src/app/defaults.rs: MIN_DT_DEFAULT,
  MAX_DT_DEFAULT, MAX_DT_INTERVAL_MULTIPLIER, MIN_STATE_FLUSH,
  DEFAULT_CMD_TIMEOUT_CAP, SOCKET_IO_TIMEOUT, SOCKET_SLEEP_CHUNK,
  ANTI_WINDUP_TT_INTERVAL_MULTIPLIER. Replaces duplicated literals in
  loop_runtime.rs, cli/parse.rs, socket.rs, and main.rs.
- Add lib.rs doc comment stating pid-ctl has no stable library API.

No behaviour changes for the CLI; full test suite passes (ignored count
drops from 3 to 2), cargo fmt/clippy clean on default and no-default
feature sets.

https://claude.ai/code/session_01WXqs85LL7P6EZSUXuAj1rC