### PR TITLE
chore: scrub remaining cruft from codebase

### DIFF
--- a/crates/pid-ctl-core/src/lib.rs
+++ b/crates/pid-ctl-core/src/lib.rs
@@ -431,15 +431,3 @@ fn ramp_toward(current: f64, target: f64, max_delta: f64) -> f64 {
         current - max_delta
     }
 }
-
-#[cfg(test)]
-mod proptest_smoke {
-    use proptest::prelude::*;
-
-    proptest! {
-        #[test]
-        fn proptest_toolchain_smoke(x in 0i32..10) {
-            prop_assert!((0..10).contains(&x));
-        }
-    }
-}

--- a/crates/pid-ctl-sim/src/main.rs
+++ b/crates/pid-ctl-sim/src/main.rs
@@ -186,9 +186,7 @@ fn build_plant(kind: PlantKind, o: &HashMap<String, f64>) -> Result<Plant, SimEr
                 t_ambient: g("t_ambient").unwrap_or(20.0),
                 k_heat: g("k_heat").unwrap_or(0.01),
             };
-            let t = g("t")
-                .or_else(|| g("t_initial"))
-                .unwrap_or(params.t_ambient);
+            let t = g("t").unwrap_or(params.t_ambient);
             params.validate()?;
             Ok(Plant::Thermal { params, t })
         }

--- a/crates/pid-ctl/src/tune/tests.rs
+++ b/crates/pid-ctl/src/tune/tests.rs
@@ -47,13 +47,8 @@ fn spark_marker_row_places_pipe_at_tick_column() {
     assert_eq!(row.chars().nth(3), Some('|'));
 }
 
-/// Regression test: sparkline slots must use Fill so they never overflow their parent
-/// in ratatui 0.30's layout engine (which replaced cassowary with kasuari).
-///
-/// Previously they used `Constraint::Length(2)` — fixed slots that summed to more rows
-/// than the parent had, causing the layout to overflow and widgets to overlap content
-/// above them.  Now they use `Constraint::Fill(1)` which distributes remaining height
-/// proportionally and is guaranteed to never overflow.
+/// Regression: sparkline slots must use `Constraint::Fill` so they cannot overflow
+/// their parent in ratatui's layout engine.
 #[test]
 fn sparkline_constraints_use_fill() {
     use ratatui::layout::Constraint;

--- a/crates/pid-ctl/tests/req/req_flag_validation.rs
+++ b/crates/pid-ctl/tests/req/req_flag_validation.rs
@@ -4,7 +4,7 @@
 use assert_cmd::Command;
 use predicates::str::contains;
 
-// --- Bugs: these test plan-required rejections that the CLI currently fails to enforce ---
+// --- CLI validation: plan-required rejections enforced at parse time ---
 
 /// pid-ctl-s4z: pipe + --pv must exit 3.
 /// Plan: "pipe reads PV from stdin intrinsically — PV source flags are not accepted"
@@ -41,7 +41,7 @@ fn duplicate_pv_flags_rejected() {
         .stderr(contains("only one PV source may be specified"));
 }
 
-// --- Unimplemented: --scale and --cv-precision (pid-ctl-7q1) ---
+// --- PV/CV formatting: --scale and --cv-precision (pid-ctl-7q1) ---
 
 /// pid-ctl-7q1: --scale multiplies raw PV before filtering or PID.
 #[test]

--- a/crates/pid-ctl/tests/req/req_loop.rs
+++ b/crates/pid-ctl/tests/req/req_loop.rs
@@ -159,22 +159,6 @@ fn loop_cv_fail_after_exits_2() {
     cmd.assert().code(2);
 }
 
-/// pid-ctl-qde: loop with SIGTERM writes safe-cv and exits 0.
-///
-/// Marked `#[ignore]` because it requires sending SIGTERM to the child process,
-/// which is platform-specific and timing-sensitive in CI.  Run manually with
-/// `cargo test -- --ignored loop_shutdown_writes_safe_cv`.
-#[test]
-#[ignore = "requires SIGTERM signal testing — run manually"]
-fn loop_shutdown_writes_safe_cv() {
-    // Implementation would:
-    // 1. Start loop with --safe-cv 0.0 --cv-file <tmp>
-    // 2. Wait for first tick
-    // 3. Send SIGTERM to child PID
-    // 4. Assert exit code 0
-    // 5. Assert cv file contains "0.00"
-}
-
 /// pid-ctl-qde: loop appends NDJSON lines to the log file.
 ///
 /// Marked `#[ignore]` because timing-dependent process-kill approach is racy on


### PR DESCRIPTION
Removes a handful of leftovers that survived the prior tech-debt sweeps:

- Drop the tautological `proptest_smoke` toolchain test in pid-ctl-core
  (real proptest coverage lives in tests/req/).
- Remove the undocumented `t_initial` parameter alias in pid-ctl-sim's
  thermal plant init — `t` is the canonical key everywhere else and
  `t_initial` was unreferenced anywhere in the repo.
- Delete the empty `loop_shutdown_writes_safe_cv` test stub: an
  `#[ignore]`'d function whose body was just pseudocode comments
  describing what it "would do".
- Fix two stale section headers in req_flag_validation.rs that
  described the tests below as "Bugs" / "Unimplemented" when both
  sets are now passing tests of enforced behavior.
- Trim the cassowary→kasuari implementation history out of the
  sparkline-constraints regression doc-comment.