### PR TITLE
feat: add `pid-ctl replay` subcommand (issue #28)

### DIFF
--- a/crates/pid-ctl/src/app/mod.rs
+++ b/crates/pid-ctl/src/app/mod.rs
@@ -4,6 +4,7 @@ pub mod adapters_build;
 pub mod defaults;
 pub mod logger;
 pub mod loop_runtime;
+pub mod replay;
 pub mod snapshot_persister;
 #[cfg(unix)]
 pub mod socket_dispatch;

--- a/crates/pid-ctl/src/app/replay.rs
+++ b/crates/pid-ctl/src/app/replay.rs
@@ -1,0 +1,226 @@
+//! Pure log-driven replay: re-runs `PidController` against recorded PV/dt values
+//! from an NDJSON log, producing a counterfactual CV stream.
+
+use crate::app::{STATE_SCHEMA_VERSION, now_iso8601};
+use pid_ctl_core::{ConfigError, PidConfig, PidController, StepInput};
+use serde::Serialize;
+use std::fmt;
+use std::io::{self, BufRead, Write};
+
+/// Errors that can arise during a replay run.
+#[derive(Debug)]
+pub enum ReplayError {
+    Io(io::Error),
+    Json {
+        line: u64,
+        source: serde_json::Error,
+    },
+    MissingField {
+        line: u64,
+        field: &'static str,
+    },
+    Config(ConfigError),
+}
+
+impl fmt::Display for ReplayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Json { line, source } => write!(f, "line {line}: invalid JSON: {source}"),
+            Self::MissingField { line, field } => {
+                write!(
+                    f,
+                    "line {line}: incomplete log record — missing required field `{field}`"
+                )
+            }
+            Self::Config(e) => write!(f, "invalid PID configuration: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ReplayError {}
+
+impl From<io::Error> for ReplayError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<ConfigError> for ReplayError {
+    fn from(e: ConfigError) -> Self {
+        Self::Config(e)
+    }
+}
+
+/// A single replayed iteration record written to the output NDJSON log.
+#[derive(Serialize)]
+pub struct ReplayRecord {
+    pub schema_version: u64,
+    pub ts: String,
+    pub iter: u64,
+    pub pv: f64,
+    pub sp: f64,
+    pub err: f64,
+    pub p: f64,
+    pub i: f64,
+    pub d: f64,
+    pub cv: f64,
+    pub i_acc: f64,
+    pub dt: f64,
+}
+
+/// CV delta statistics comparing replayed output against the original log.
+pub struct DiffSummary {
+    pub max_diff: f64,
+    pub rms_diff: f64,
+    /// Number of iteration records processed.
+    pub n: u64,
+}
+
+/// Re-runs the PID controller against every iteration record in `reader`.
+///
+/// `pid_config.setpoint` is used as-is when `setpoint_from_cli` is `true`; otherwise
+/// the setpoint is taken from the first iteration record's `sp` field.
+///
+/// Replayed records are written as NDJSON to `output` when provided.
+/// Returns [`DiffSummary`] comparing replayed CV values against the original log's `cv`.
+///
+/// # Errors
+///
+/// Returns [`ReplayError`] on I/O failure, malformed JSON, a missing required field
+/// in an iteration record, or an invalid PID configuration.
+///
+/// # Panics
+///
+/// Cannot panic: the `unwrap()` on the controller is guarded by the `is_none()` check
+/// that initialises it on the same path.
+#[allow(clippy::too_many_lines)]
+pub fn replay(
+    reader: impl BufRead,
+    mut pid_config: PidConfig,
+    setpoint_from_cli: bool,
+    mut output: Option<&mut dyn Write>,
+) -> Result<DiffSummary, ReplayError> {
+    let mut controller: Option<PidController> = None;
+    let mut prev_applied_cv = 0.0_f64;
+    let mut iter = 0_u64;
+
+    let mut sum_sq_diff = 0.0_f64;
+    let mut max_diff = 0.0_f64;
+    let mut n = 0_u64;
+
+    for (line_idx, raw_line) in reader.lines().enumerate() {
+        let line_num = (line_idx + 1) as u64;
+        let raw = raw_line?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let v: serde_json::Value =
+            serde_json::from_str(trimmed).map_err(|source| ReplayError::Json {
+                line: line_num,
+                source,
+            })?;
+
+        // Skip control-event records — they carry an "event" string field.
+        if v.get("event").is_some() {
+            continue;
+        }
+
+        let has_pv = v.get("pv").is_some();
+        let has_dt = v.get("dt").is_some();
+
+        // Skip lines that appear to be neither events nor iteration records.
+        if !has_pv && !has_dt {
+            continue;
+        }
+
+        if !has_pv {
+            return Err(ReplayError::MissingField {
+                line: line_num,
+                field: "pv",
+            });
+        }
+        if !has_dt {
+            return Err(ReplayError::MissingField {
+                line: line_num,
+                field: "dt",
+            });
+        }
+
+        let pv = v["pv"].as_f64().ok_or(ReplayError::MissingField {
+            line: line_num,
+            field: "pv",
+        })?;
+        let dt = v["dt"].as_f64().ok_or(ReplayError::MissingField {
+            line: line_num,
+            field: "dt",
+        })?;
+        let orig_cv = v.get("cv").and_then(serde_json::Value::as_f64);
+
+        // Initialise the controller on the first iteration record.
+        if controller.is_none() {
+            if !setpoint_from_cli {
+                let sp = v["sp"].as_f64().ok_or(ReplayError::MissingField {
+                    line: line_num,
+                    field: "sp",
+                })?;
+                pid_config.setpoint = sp;
+            }
+            controller = Some(PidController::new(pid_config.clone())?);
+        }
+        let ctl = controller.as_mut().unwrap();
+
+        let step = ctl.step(StepInput {
+            pv,
+            dt,
+            prev_applied_cv,
+        });
+        prev_applied_cv = step.cv;
+        iter += 1;
+
+        // Accumulate diff stats.
+        if let Some(ocv) = orig_cv {
+            let diff = (step.cv - ocv).abs();
+            if diff > max_diff {
+                max_diff = diff;
+            }
+            sum_sq_diff += diff * diff;
+            n += 1;
+        }
+
+        // Write replayed record to output log.
+        if let Some(ref mut w) = output {
+            let record = ReplayRecord {
+                schema_version: STATE_SCHEMA_VERSION,
+                ts: now_iso8601(),
+                iter,
+                pv,
+                sp: pid_config.setpoint,
+                err: ctl.last_error().unwrap_or(0.0),
+                p: step.p_term,
+                i: step.i_term,
+                d: step.d_term,
+                cv: step.cv,
+                i_acc: step.i_acc,
+                dt,
+            };
+            let json = serde_json::to_string(&record).map_err(io::Error::other)?;
+            writeln!(w, "{json}")?;
+        }
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let rms_diff = if n == 0 {
+        0.0
+    } else {
+        (sum_sq_diff / n as f64).sqrt()
+    };
+
+    Ok(DiffSummary {
+        max_diff,
+        rms_diff,
+        n,
+    })
+}

--- a/crates/pid-ctl/src/cli/mod.rs
+++ b/crates/pid-ctl/src/cli/mod.rs
@@ -12,12 +12,12 @@ pub(crate) use parse::parse_duration_flag;
 #[cfg(unix)]
 pub(crate) use parse::{get_socket_path, parse_set_args};
 pub(crate) use parse::{
-    get_state_path, parse_f64_value, parse_loop, parse_once, parse_pipe, parse_status_flags,
-    resolve_pv,
+    get_state_path, parse_f64_value, parse_loop, parse_once, parse_pipe, parse_replay,
+    parse_status_flags, resolve_pv,
 };
 pub(crate) use raw::{Cli, SubCommand};
 #[cfg(unix)]
 pub(crate) use raw::{SetRawArgs, SocketOnlyArgs};
 pub(crate) use types::{
-    LoopArgs, LoopRuntimeConfig, OnceArgs, OutputFormat, PipeArgs, StatusFlags,
+    LoopArgs, LoopRuntimeConfig, OnceArgs, OutputFormat, PipeArgs, ReplayArgs, StatusFlags,
 };

--- a/crates/pid-ctl/src/cli/parse.rs
+++ b/crates/pid-ctl/src/cli/parse.rs
@@ -1,7 +1,7 @@
-use super::raw::{LoopRawArgs, OnceRawArgs, PipeRawArgs, StatusRawArgs};
+use super::raw::{LoopRawArgs, OnceRawArgs, PipeRawArgs, ReplayRawArgs, StatusRawArgs};
 use super::types::{
     CvMode, CvSinkConfig, LoopArgs, LoopPvSource, LoopRuntimeConfig, OnceArgs, OncePvSource,
-    OutputFormat, PidFlags, PipeArgs, SetArgs, StatusFlags,
+    OutputFormat, PidFlags, PipeArgs, ReplayArgs, SetArgs, StatusFlags,
 };
 use super::user_set::UserSet;
 use crate::CliError;
@@ -501,5 +501,41 @@ pub(crate) fn resolve_pv(source: &OncePvSource, cmd_timeout: Duration) -> io::Re
 pub(crate) fn parse_f64_value(flag: &str, value: &str) -> Result<f64, CliError> {
     value.parse::<f64>().map_err(|error| {
         CliError::config(format!("{flag} expects a float, got `{value}`: {error}"))
+    })
+}
+
+pub(crate) fn parse_replay(raw: &ReplayRawArgs) -> Result<ReplayArgs, CliError> {
+    let pid_flags = raw.pid.to_pid_flags()?;
+    let setpoint_from_cli = pid_flags.setpoint.is_some();
+    let defaults = PidConfig::default();
+
+    let pid_config = PidConfig {
+        setpoint: pid_flags.setpoint.unwrap_or(0.0),
+        kp: pid_flags.kp.unwrap_or(defaults.kp),
+        ki: pid_flags.ki.unwrap_or(defaults.ki),
+        kd: pid_flags.kd.unwrap_or(defaults.kd),
+        out_min: pid_flags.out_min.unwrap_or(defaults.out_min),
+        out_max: pid_flags.out_max.unwrap_or(defaults.out_max),
+        deadband: pid_flags.deadband.unwrap_or(defaults.deadband),
+        setpoint_ramp: pid_flags.setpoint_ramp.or(defaults.setpoint_ramp),
+        slew_rate: pid_flags.slew_rate.or(defaults.slew_rate),
+        pv_filter_alpha: pid_flags
+            .pv_filter_alpha
+            .unwrap_or(defaults.pv_filter_alpha),
+        anti_windup: pid_flags.anti_windup.unwrap_or(defaults.anti_windup),
+        anti_windup_tt: pid_flags.anti_windup_tt,
+        tt_upper_bound: None,
+    };
+
+    pid_config
+        .validate()
+        .map_err(|e| CliError::config(e.to_string()))?;
+
+    Ok(ReplayArgs {
+        log_path: raw.log.clone(),
+        pid_config,
+        setpoint_from_cli,
+        output_log: raw.output_log.clone(),
+        diff: raw.diff,
     })
 }

--- a/crates/pid-ctl/src/cli/raw.rs
+++ b/crates/pid-ctl/src/cli/raw.rs
@@ -63,6 +63,8 @@ pub(crate) enum SubCommand {
     Loop(LoopRawArgs),
     /// Read PV lines from stdin and emit CV to stdout
     Pipe(PipeRawArgs),
+    /// Re-run PID over a recorded NDJSON log with new gains
+    Replay(ReplayRawArgs),
     /// Show controller status
     Status(StatusRawArgs),
     /// Send a set command via socket
@@ -689,4 +691,23 @@ pub(crate) struct StateOnlyArgs {
     /// Path to state file
     #[arg(long)]
     pub(crate) state: Option<PathBuf>,
+}
+
+/// `replay` — re-run the PID controller against a recorded NDJSON log.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct ReplayRawArgs {
+    /// Input NDJSON log file (produced by --log)
+    #[arg(long, required = true)]
+    pub(super) log: PathBuf,
+
+    #[command(flatten)]
+    pub(super) pid: PidRawArgs,
+
+    /// Write replayed NDJSON records to this file
+    #[arg(long)]
+    pub(super) output_log: Option<PathBuf>,
+
+    /// Print CV delta summary (max diff, RMS diff) to stdout
+    #[arg(long)]
+    pub(super) diff: bool,
 }

--- a/crates/pid-ctl/src/cli/types.rs
+++ b/crates/pid-ctl/src/cli/types.rs
@@ -217,3 +217,13 @@ pub(crate) struct StatusFlags {
     #[cfg(unix)]
     pub(crate) socket_path: Option<PathBuf>,
 }
+
+pub(crate) struct ReplayArgs {
+    pub(crate) log_path: PathBuf,
+    pub(crate) pid_config: PidConfig,
+    /// `true` when `--setpoint` was explicitly provided on the CLI; `false` means
+    /// the setpoint will be read from the first iteration record in the log.
+    pub(crate) setpoint_from_cli: bool,
+    pub(crate) output_log: Option<PathBuf>,
+    pub(crate) diff: bool,
+}

--- a/crates/pid-ctl/src/cmd/cmd_replay.rs
+++ b/crates/pid-ctl/src/cmd/cmd_replay.rs
@@ -1,0 +1,52 @@
+use crate::{CliError, ReplayArgs};
+use pid_ctl::app::replay::{self, DiffSummary};
+use std::fs::File;
+use std::io::BufReader;
+
+pub(crate) fn run_replay(args: &ReplayArgs) -> Result<(), CliError> {
+    let file = File::open(&args.log_path).map_err(|e| {
+        CliError::new(
+            1,
+            format!("failed to open log file {}: {e}", args.log_path.display()),
+        )
+    })?;
+    let reader = BufReader::new(file);
+
+    let mut out_file: Option<File> = if let Some(ref path) = args.output_log {
+        let f = File::create(path).map_err(|e| {
+            CliError::new(
+                1,
+                format!("failed to create output log {}: {e}", path.display()),
+            )
+        })?;
+        Some(f)
+    } else {
+        None
+    };
+
+    let output: Option<&mut dyn std::io::Write> =
+        out_file.as_mut().map(|f| f as &mut dyn std::io::Write);
+
+    let summary = replay::replay(
+        reader,
+        args.pid_config.clone(),
+        args.setpoint_from_cli,
+        output,
+    )
+    .map_err(|e| CliError::new(1, e.to_string()))?;
+
+    if args.diff {
+        print_diff(&summary);
+    }
+
+    Ok(())
+}
+
+fn print_diff(s: &DiffSummary) {
+    let line = serde_json::json!({
+        "n": s.n,
+        "max_diff": s.max_diff,
+        "rms_diff": s.rms_diff,
+    });
+    println!("{line}");
+}

--- a/crates/pid-ctl/src/cmd/mod.rs
+++ b/crates/pid-ctl/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 mod cmd_loop;
 mod cmd_once;
 mod cmd_pipe;
+mod cmd_replay;
 #[cfg(unix)]
 mod cmd_socket;
 mod cmd_state;
@@ -8,6 +9,7 @@ mod cmd_state;
 pub(crate) use cmd_loop::run_loop;
 pub(crate) use cmd_once::run_once;
 pub(crate) use cmd_pipe::run_pipe;
+pub(crate) use cmd_replay::run_replay;
 #[cfg(unix)]
 pub(crate) use cmd_socket::{
     run_socket_hold, run_socket_reset, run_socket_resume, run_socket_save, run_socket_set,

--- a/crates/pid-ctl/src/main.rs
+++ b/crates/pid-ctl/src/main.rs
@@ -66,6 +66,10 @@ fn run(
             }
             cmd::run_loop(&mut parsed)
         }
+        SubCommand::Replay(raw) => {
+            let args = parse_replay(&raw)?;
+            cmd::run_replay(&args)
+        }
         SubCommand::Status(raw) => {
             let flags = parse_status_flags(&raw)?;
             cmd::run_status_dispatch(&flags)

--- a/crates/pid-ctl/tests/req/req_replay.rs
+++ b/crates/pid-ctl/tests/req/req_replay.rs
@@ -1,0 +1,501 @@
+//! Social (integration-point) tests for `pid-ctl replay`.
+//! These tests drive the CLI binary and verify observable contracts:
+//! exit codes, stdout content, output-log NDJSON structure, and diff summaries.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::tempdir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a minimal valid NDJSON log with the given PV/cv/sp values and dt=1.0.
+/// Each line is an iteration record with all fields `replay` needs.
+fn make_ndjson_log(records: &[(f64, f64, f64)]) -> String {
+    // (pv, cv, sp)
+    records
+        .iter()
+        .enumerate()
+        .map(|(i, (pv, cv, sp))| {
+            format!(
+                r#"{{"schema_version":1,"ts":"2026-01-01T00:00:00Z","iter":{iter},"pv":{pv},"sp":{sp},"err":{err},"p":{cv},"i":0.0,"d":0.0,"cv":{cv},"i_acc":0.0,"dt":1.0}}"#,
+                iter = i + 1,
+                pv = pv,
+                sp = sp,
+                err = sp - pv,
+                cv = cv,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n"
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: same gains → numerically identical CV
+// ---------------------------------------------------------------------------
+
+/// Replaying a log with the exact same gains must produce the same CV values,
+/// within floating-point precision (issue §Verification).
+#[test]
+fn replay_round_trip_same_gains_produces_identical_cv() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out_path = dir.path().join("replayed.ndjson");
+
+    // Generate log via `pipe --dt 1.0` so dt is fixed.
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args([
+            "pipe",
+            "--setpoint",
+            "55.0",
+            "--kp",
+            "1.0",
+            "--ki",
+            "0.1",
+            "--kd",
+            "0.0",
+            "--dt",
+            "1.0",
+            "--log",
+        ])
+        .arg(&log_path)
+        .write_stdin("50.0\n51.0\n52.0\n53.0\n")
+        .assert()
+        .success();
+
+    // Replay with the same gains.
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--ki", "0.1", "--kd", "0.0", "--output-log"])
+        .arg(&out_path)
+        .assert()
+        .success();
+
+    // Parse both logs and compare CV values.
+    let original = std::fs::read_to_string(&log_path).expect("read source log");
+    let replayed = std::fs::read_to_string(&out_path).expect("read replayed log");
+
+    let orig_cvs: Vec<f64> = original
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).expect("valid JSON"))
+        .filter(|v| v.get("event").is_none())
+        .map(|v| v["cv"].as_f64().expect("cv field"))
+        .collect();
+
+    let replay_cvs: Vec<f64> = replayed
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).expect("valid JSON"))
+        .filter(|v| v.get("event").is_none())
+        .map(|v| v["cv"].as_f64().expect("cv field"))
+        .collect();
+
+    assert_eq!(orig_cvs.len(), replay_cvs.len(), "record counts must match");
+    assert!(!orig_cvs.is_empty(), "must have at least one record");
+
+    for (i, (oc, rc)) in orig_cvs.iter().zip(replay_cvs.iter()).enumerate() {
+        let diff = (oc - rc).abs();
+        assert!(
+            diff <= f64::EPSILON * oc.abs().max(1.0),
+            "tick {}: orig_cv={oc} replayed_cv={rc} diff={diff} exceeds 1 ULP",
+            i + 1
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Different gains → deterministic, reproducible output
+// ---------------------------------------------------------------------------
+
+/// Replaying with different gains must be deterministic: two runs with the same
+/// input produce bit-identical output files.
+#[test]
+fn replay_different_gains_is_deterministic() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out1 = dir.path().join("replay1.ndjson");
+    let out2 = dir.path().join("replay2.ndjson");
+
+    // Build a fixed log directly (no wall-clock dt involved).
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0), (51.0, 4.0, 55.0), (52.0, 3.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    for out in [&out1, &out2] {
+        Command::cargo_bin("pid-ctl")
+            .unwrap()
+            .args(["replay", "--log"])
+            .arg(&log_path)
+            .args(["--kp", "1.5", "--ki", "0.05", "--kd", "0.0", "--output-log"])
+            .arg(out)
+            .assert()
+            .success();
+    }
+
+    let content1 = std::fs::read_to_string(&out1).unwrap();
+    let content2 = std::fs::read_to_string(&out2).unwrap();
+
+    // cv and i_acc must be identical across both runs.
+    let cvs1 = extract_field_f64s(&content1, "cv");
+    let cvs2 = extract_field_f64s(&content2, "cv");
+    assert_eq!(cvs1, cvs2, "cv values must be identical across replay runs");
+
+    let i_accs1 = extract_field_f64s(&content1, "i_acc");
+    let i_accs2 = extract_field_f64s(&content2, "i_acc");
+    assert_eq!(
+        i_accs1, i_accs2,
+        "i_acc must be identical across replay runs"
+    );
+}
+
+fn extract_field_f64s(ndjson: &str, field: &str) -> Vec<f64> {
+    ndjson
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).expect("valid JSON"))
+        .filter(|v| v.get("event").is_none())
+        .map(|v| v[field].as_f64().expect("numeric field"))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Output log NDJSON structure
+// ---------------------------------------------------------------------------
+
+/// `--output-log` writes valid NDJSON with all required fields per record.
+#[test]
+fn replay_output_log_has_required_fields() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out_path = dir.path().join("out.ndjson");
+
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0), (51.0, 4.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--output-log"])
+        .arg(&out_path)
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&out_path).expect("read output log");
+    let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+
+    assert_eq!(lines.len(), 2, "expected 2 output records");
+
+    for line in &lines {
+        let v: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
+        for field in [
+            "schema_version",
+            "ts",
+            "iter",
+            "pv",
+            "sp",
+            "err",
+            "p",
+            "i",
+            "d",
+            "cv",
+            "i_acc",
+            "dt",
+        ] {
+            assert!(v.get(field).is_some(), "missing field `{field}` in: {line}");
+        }
+    }
+}
+
+/// iter in the output log increments starting from 1.
+#[test]
+fn replay_output_log_iter_increments() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out_path = dir.path().join("out.ndjson");
+
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0), (51.0, 4.0, 55.0), (52.0, 3.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--output-log"])
+        .arg(&out_path)
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    let iters: Vec<u64> = content
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| {
+            let v: serde_json::Value = serde_json::from_str(l).unwrap();
+            v["iter"].as_u64().unwrap()
+        })
+        .collect();
+
+    assert_eq!(iters, vec![1, 2, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// Event records are skipped (not treated as iteration records)
+// ---------------------------------------------------------------------------
+
+/// NDJSON logs contain event records (e.g. `gains_changed`). Replay must skip
+/// them and process only the iteration records.
+#[test]
+fn replay_skips_event_records() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out_path = dir.path().join("out.ndjson");
+
+    // Mix event records and iteration records.
+    let log_content = [
+        r#"{"schema_version":1,"ts":"2026-01-01T00:00:00Z","event":"gains_changed","kp":1.0,"ki":0.0,"kd":0.0,"sp":55.0,"iter":0,"source":"cli"}"#,
+        r#"{"schema_version":1,"ts":"2026-01-01T00:00:01Z","iter":1,"pv":50.0,"sp":55.0,"err":5.0,"p":5.0,"i":0.0,"d":0.0,"cv":5.0,"i_acc":0.0,"dt":1.0}"#,
+        r#"{"schema_version":1,"ts":"2026-01-01T00:00:01Z","event":"dt_skipped","raw_dt":0.001,"min_dt":0.01,"max_dt":10.0}"#,
+        r#"{"schema_version":1,"ts":"2026-01-01T00:00:02Z","iter":2,"pv":51.0,"sp":55.0,"err":4.0,"p":4.0,"i":0.0,"d":0.0,"cv":4.0,"i_acc":0.0,"dt":1.0}"#,
+    ]
+    .join("\n") + "\n";
+
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--output-log"])
+        .arg(&out_path)
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "only iteration records should appear in output"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --diff flag
+// ---------------------------------------------------------------------------
+
+/// `--diff` prints a JSON summary to stdout with `n`, `max_diff`, `rms_diff`.
+#[test]
+fn replay_diff_flag_prints_summary_fields() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0), (51.0, 4.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    let output = Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--diff"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("diff output is JSON");
+
+    assert!(v.get("n").is_some(), "missing `n` in diff output");
+    assert!(
+        v.get("max_diff").is_some(),
+        "missing `max_diff` in diff output"
+    );
+    assert!(
+        v.get("rms_diff").is_some(),
+        "missing `rms_diff` in diff output"
+    );
+    assert_eq!(v["n"].as_u64().unwrap(), 2);
+}
+
+/// Round-trip: same gains → `max_diff` and `rms_diff` are both effectively zero.
+#[test]
+fn replay_diff_round_trip_is_zero() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+
+    // Log was produced with kp=1.0, ki=0, kd=0, sp=55 — so cv = sp - pv.
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0), (51.0, 4.0, 55.0), (52.0, 3.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    let output = Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--diff"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+
+    let max_diff = v["max_diff"].as_f64().unwrap();
+    let rms_diff = v["rms_diff"].as_f64().unwrap();
+    assert!(
+        max_diff < 1e-9,
+        "max_diff should be ~0 for round-trip, got {max_diff}"
+    );
+    assert!(
+        rms_diff < 1e-9,
+        "rms_diff should be ~0 for round-trip, got {rms_diff}"
+    );
+}
+
+/// `--diff` and `--output-log` can be combined: both the diff and the log are produced.
+#[test]
+fn replay_diff_and_output_log_combined() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out_path = dir.path().join("out.ndjson");
+
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    let output = Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--diff", "--output-log"])
+        .arg(&out_path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    // Diff summary on stdout.
+    let stdout = String::from_utf8(output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(v.get("n").is_some());
+
+    // Output log written.
+    let out_content = std::fs::read_to_string(&out_path).unwrap();
+    assert!(
+        !out_content.trim().is_empty(),
+        "output log must not be empty"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Incomplete log record validation
+// ---------------------------------------------------------------------------
+
+/// A log record with `dt` but no `pv` must produce a clear error and non-zero exit.
+#[test]
+fn replay_rejects_missing_pv() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("bad.ndjson");
+
+    // Has dt but no pv.
+    std::fs::write(
+        &log_path,
+        r#"{"schema_version":1,"ts":"2026-01-01T00:00:00Z","iter":1,"sp":55.0,"err":5.0,"cv":5.0,"i_acc":0.0,"dt":1.0}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--diff"])
+        .assert()
+        .failure()
+        .stderr(contains("pv"));
+}
+
+/// A log record with `pv` but no `dt` must produce a clear error and non-zero exit.
+#[test]
+fn replay_rejects_missing_dt() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("bad.ndjson");
+
+    // Has pv but no dt.
+    std::fs::write(
+        &log_path,
+        r#"{"schema_version":1,"ts":"2026-01-01T00:00:00Z","iter":1,"pv":50.0,"sp":55.0,"err":5.0,"cv":5.0,"i_acc":0.0}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "1.0", "--diff"])
+        .assert()
+        .failure()
+        .stderr(contains("dt"));
+}
+
+// ---------------------------------------------------------------------------
+// Error: --log file does not exist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replay_missing_log_file_exits_nonzero() {
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args([
+            "replay",
+            "--log",
+            "/nonexistent/path/missing.ndjson",
+            "--kp",
+            "1.0",
+            "--diff",
+        ])
+        .assert()
+        .failure();
+}
+
+// ---------------------------------------------------------------------------
+// Setpoint auto-detected from log when --setpoint is absent
+// ---------------------------------------------------------------------------
+
+/// Without `--setpoint`, replay reads sp from the first log record and uses it.
+/// CV should equal kp*(sp-pv) for a pure-P controller.
+#[test]
+fn replay_setpoint_from_log_when_not_given() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("source.ndjson");
+    let out_path = dir.path().join("out.ndjson");
+
+    // sp=55.0, pv=50.0 → with kp=2.0, expected CV=10.0
+    let log_content = make_ndjson_log(&[(50.0, 5.0, 55.0)]);
+    std::fs::write(&log_path, &log_content).unwrap();
+
+    Command::cargo_bin("pid-ctl")
+        .unwrap()
+        .args(["replay", "--log"])
+        .arg(&log_path)
+        .args(["--kp", "2.0", "--output-log"])
+        .arg(&out_path)
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    let line = content.lines().find(|l| !l.is_empty()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(line).unwrap();
+    let cv = v["cv"].as_f64().unwrap();
+    assert!(
+        (cv - 10.0).abs() < 1e-9,
+        "expected CV=10.0 (kp=2 * error=5), got {cv}"
+    );
+}

--- a/crates/pid-ctl/tests/requirements.rs
+++ b/crates/pid-ctl/tests/requirements.rs
@@ -34,6 +34,8 @@ mod req_pv_source;
 mod req_pv_stdin_verify_cv;
 #[path = "req/req_reliability.rs"]
 mod req_reliability;
+#[path = "req/req_replay.rs"]
+mod req_replay;
 #[path = "req/req_sim_loop.rs"]
 mod req_sim_loop;
 #[path = "req/req_socket.rs"]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #28. Adds `pid-ctl replay` — a pure log-driven subcommand that re-runs the PID core against recorded PV/dt values from an NDJSON `--log` file with new (or the same) gains, enabling counterfactual what-if analysis.

- **`app/replay.rs`** — core driver: reads each iteration record from the NDJSON log, calls `PidController::step` with the recorded `pv` and `dt`, and streams replayed records to an optional output file. Event records (`gains_changed`, `dt_skipped`, etc.) are silently skipped; iteration records missing `pv` or `dt` produce a clear error with the line number.
- **`cmd/cmd_replay.rs`** — CLI wiring: opens files, delegates to the replay engine, prints the `--diff` JSON summary to stdout when requested.
- **New subcommand** with flags matching the issue spec: `--log` (required input), `--kp`/`--ki`/`--kd`/`--setpoint` (all optional — setpoint auto-detected from the first log record when absent), `--out-min`/`--out-max` and other standard PID flags, `--output-log`, and `--diff`.

## Test plan

12 social integration tests in `tests/req/req_replay.rs`, all green:

- [ ] Round-trip: `pipe --dt 1.0` → log → `replay` with same gains → CV values are bit-identical (within 1 ULP)
- [ ] Different gains produce deterministic, reproducible output (two runs are identical)
- [ ] `--output-log` writes valid NDJSON with all required fields (`schema_version`, `ts`, `iter`, `pv`, `sp`, `err`, `p`, `i`, `d`, `cv`, `i_acc`, `dt`)
- [ ] `iter` increments from 1 in output log
- [ ] Event records (`gains_changed`, `dt_skipped`) are skipped and do not appear in output
- [ ] `--diff` prints JSON with `n`, `max_diff`, `rms_diff`; round-trip diff is ~0
- [ ] `--diff` and `--output-log` work in combination
- [ ] Missing `pv` field → non-zero exit + stderr mentions `pv`
- [ ] Missing `dt` field → non-zero exit + stderr mentions `dt`
- [ ] Non-existent `--log` file → non-zero exit
- [ ] Setpoint auto-detected from first log record's `sp` when `--setpoint` not given

https://claude.ai/code/session_013ZVtCjwiABE1D13qVHDKyr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZVtCjwiABE1D13qVHDKyr)_